### PR TITLE
fix: can not run bechmark in MacOS

### DIFF
--- a/benchmark/src/bin/clickbench_client.rs
+++ b/benchmark/src/bin/clickbench_client.rs
@@ -459,7 +459,10 @@ pub async fn main() -> Result<()> {
 
             networks.refresh(true);
             // for mac its lo0 and for linux its lo.
-            let network_info = networks.get("lo0").or_else(|| networks.get("lo")).expect("No loopback interface found in networks");
+            let network_info = networks
+                .get("lo0")
+                .or_else(|| networks.get("lo"))
+                .expect("No loopback interface found in networks");
             let physical_plan_with_metrics =
                 DisplayableExecutionPlan::with_metrics(physical_plan.as_ref());
 

--- a/benchmark/src/bin/clickbench_client.rs
+++ b/benchmark/src/bin/clickbench_client.rs
@@ -458,8 +458,8 @@ pub async fn main() -> Result<()> {
             info!("Query execution time: {:?}", elapsed);
 
             networks.refresh(true);
-            let network_info = networks.get("lo").unwrap();
-
+            // for mac its lo0 and for linux its lo.
+            let network_info = networks.get("lo0").or_else(|| networks.get("lo")).expect("No loopback interface found in networks");
             let physical_plan_with_metrics =
                 DisplayableExecutionPlan::with_metrics(physical_plan.as_ref());
 


### PR DESCRIPTION
This patch fix can not run benchmark on MacOS
error 

```cli
thread 'main' panicked at benchmark/src/bin/clickbench_client.rs:461:51:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
for the reason that for some os its "lo0" instead of "lo"

more detail:
https://www.ibm.com/docs/en/was-nd/8.5.5?topic=machines-aliasing-network-interface-card-loopback-device