### PR TITLE
Support multi-col predicate

### DIFF
--- a/src/liquid_parquet/src/reader/runtime/parquet_bridge.rs
+++ b/src/liquid_parquet/src/reader/runtime/parquet_bridge.rs
@@ -152,7 +152,7 @@ pub(super) fn get_predicate_column_id(projection: &parquet::arrow::ProjectionMas
                 .filter_map(|(pos, &x)| if x { Some(pos) } else { None })
                 .collect::<Vec<usize>>()
         })
-        .unwrap_or_else(|| Vec::new())
+        .unwrap_or_default()
 }
 
 use parquet::arrow::async_reader::AsyncReader;


### PR DESCRIPTION
As in TPCH q4, we have a predicate `l_commitdate < l_receiptdate`, this was not supported and caused panic.

This pr allows predicate to span across multiple columns.