### PR TITLE
feat: Change PartitionedHashStore to use ART instead of hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "congee"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ca0e17406c6049cd9c2809f8d53804c7309cfaa9c41833626650fdad5e105d"
+checksum = "bf55648c2da96fa1d59d103f85ef626e1610996256cb1e9826c739f2ca5e9e3c"
 dependencies = [
  "crossbeam-epoch",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,8 +880,6 @@ dependencies = [
 [[package]]
 name = "congee"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bcc381b9ec223b2dd90d3f7d923583604e83e60e5ad03fbce517e1e62e7cd0"
 dependencies = [
  "crossbeam-epoch",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "congee"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25bcc381b9ec223b2dd90d3f7d923583604e83e60e5ad03fbce517e1e62e7cd0"
+dependencies = [
+ "crossbeam-epoch",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2855,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "bytes",
+ "congee",
  "criterion",
  "datafusion",
  "fastlanes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,9 @@ dependencies = [
 
 [[package]]
 name = "congee"
-version = "0.3.3"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ca0e17406c6049cd9c2809f8d53804c7309cfaa9c41833626650fdad5e105d"
 dependencies = [
  "crossbeam-epoch",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.16.0", features = ["v4"] }
 fastrace = "0.7"
 fastrace-futures = "0.7"
 fastrace-tonic = "0.1"
-congee = { path = "/Users/devan/Documents/OSS/congee" }
+congee = { path = "/home/devan/Documents/OSS/congee" }
 
 
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.16.0", features = ["v4"] }
 fastrace = "0.7"
 fastrace-futures = "0.7"
 fastrace-tonic = "0.1"
-congee = "0.3.3"
+congee = { path = "/Users/devan/Documents/OSS/congee" }
 
 
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ uuid = { version = "1.16.0", features = ["v4"] }
 fastrace = "0.7"
 fastrace-futures = "0.7"
 fastrace-tonic = "0.1"
-congee = "0.3.4"
+congee = "0.4.0"
 
 
 [profile.dev.package]
 insta.opt-level = 3
 
-# [patch.crates-io]
+[patch.crates-io]
 # datafusion = { path = "../datafusion/datafusion/core" }
 # datafusion-proto = { path = "../datafusion/datafusion/proto" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ uuid = { version = "1.16.0", features = ["v4"] }
 fastrace = "0.7"
 fastrace-futures = "0.7"
 fastrace-tonic = "0.1"
-congee = { path = "/home/devan/Documents/OSS/congee" }
+congee = "0.3.4"
 
 
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ uuid = { version = "1.16.0", features = ["v4"] }
 fastrace = "0.7"
 fastrace-futures = "0.7"
 fastrace-tonic = "0.1"
+congee = "0.3.3"
 
 
 [profile.dev.package]

--- a/src/liquid_parquet/Cargo.toml
+++ b/src/liquid_parquet/Cargo.toml
@@ -29,6 +29,7 @@ zerocopy = { version = "0.8.24", features = ["derive"] }
 liquid-cache-common = { workspace = true }
 fastrace = { workspace = true }
 fastrace-futures = { workspace = true }
+congee = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.19.1"

--- a/src/liquid_parquet/src/cache/mod.rs
+++ b/src/liquid_parquet/src/cache/mod.rs
@@ -1,9 +1,6 @@
 use super::liquid_array::LiquidArrayRef;
 use crate::liquid_array::ipc::{self, LiquidIPCContext};
-use crate::sync::{
-    Mutex, RwLock,
-    atomic::{AtomicU64, Ordering},
-};
+use crate::sync::{Mutex, RwLock};
 use crate::{ABLATION_STUDY_MODE, AblationStudyMode, LiquidPredicate};
 use ahash::AHashMap;
 use arrow::array::{Array, ArrayRef, BooleanArray, RecordBatch};
@@ -11,10 +8,7 @@ use arrow::buffer::BooleanBuffer;
 use arrow::compute::prep_null_mask_filter;
 use arrow_schema::{ArrowError, DataType, Field, Schema};
 use bytes::Bytes;
-use liquid_cache_common::{
-    LiquidCacheMode, cast_from_parquet_to_liquid_type, coerce_from_parquet_to_liquid_type,
-};
-use policies::LruPolicy;
+use liquid_cache_common::{LiquidCacheMode, coerce_from_parquet_to_liquid_type};
 use std::fmt::Display;
 use std::fs::File;
 use std::io::Read;

--- a/src/liquid_parquet/src/cache/mod.rs
+++ b/src/liquid_parquet/src/cache/mod.rs
@@ -89,6 +89,20 @@ impl CachedBatch {
     }
 }
 
+impl From<CachedBatch> for usize {
+    fn from(value: CachedBatch) -> Self {
+        let v = Box::new(value);
+        Box::into_raw(v) as usize
+    }
+}
+
+impl From<usize> for CachedBatch {
+    fn from(ptr: usize) -> Self {
+        assert_eq!(std::mem::size_of::<Self>(), std::mem::size_of::<usize>());
+        unsafe { *Box::from_raw(ptr as *mut CachedBatch) }
+    }
+}
+
 impl Display for CachedBatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/liquid_parquet/src/cache/mod.rs
+++ b/src/liquid_parquet/src/cache/mod.rs
@@ -118,11 +118,11 @@ mod cached_batch_tests {
     fn cached_batch_cast() {
         let array = Arc::new(Int32Array::from(vec![Some(1), None, Some(3)]));
         let cached_batch: CachedBatch = CachedBatch::ArrowMemory(array);
-        let ref_count_1 = cached_batch.reference_count();
+        let mem_size_1 = cached_batch.memory_usage_bytes();
         let batch_as_usize = usize::from(cached_batch);
         let back_to_cached_batch = CachedBatch::from(batch_as_usize);
-        let ref_count = back_to_cached_batch.reference_count();
-        assert_eq!(ref_count_1, ref_count);
+        let mem_size_2 = back_to_cached_batch.memory_usage_bytes();
+        assert_eq!(mem_size_1, mem_size_2);
     }
 }
 

--- a/src/liquid_parquet/src/cache/store.rs
+++ b/src/liquid_parquet/src/cache/store.rs
@@ -3,12 +3,12 @@ use std::fmt::{Debug, Formatter};
 use std::{fs::File, io::Write, path::PathBuf};
 
 use super::{
-    CacheEntryID, CachedBatch, LiquidCompressorStates,
     budget::BudgetAccounting,
     policies::CachePolicy,
     tracer::CacheTracer,
     transcode_liquid_inner,
     utils::{CacheConfig, ColumnAccessPath},
+    CacheEntryID, CachedBatch, LiquidCompressorStates,
 };
 use crate::liquid_array::LiquidArrayRef;
 use crate::sync::{Arc, RwLock};
@@ -524,7 +524,7 @@ mod tests {
 
     impl ArtStore {
         fn len(&self) -> usize {
-            0
+            self.art.keys().len()
         }
     }
 

--- a/src/liquid_parquet/src/cache/store.rs
+++ b/src/liquid_parquet/src/cache/store.rs
@@ -81,10 +81,10 @@ impl ArtStore {
         let guard = self.art.pin();
         for id in self.art.keys().into_iter() {
             f(
-                &CacheEntryID::from(id),
+                &id,
                 &self
                     .art
-                    .get(&CacheEntryID::from(id), &guard)
+                    .get(&id, &guard)
                     .expect("Failed to get value from ART"),
             );
         }
@@ -300,17 +300,14 @@ impl CacheStore {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::cache::{
         policies::{CachePolicy, LruPolicy},
         utils::{create_cache_store, create_entry_id, create_test_array},
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
 
-    use super::*;
-    use crate::sync::{
-        atomic::{AtomicUsize, Ordering},
-        thread,
-    };
     use arrow::array::Array;
     use liquid_cache_common::LiquidCacheMode;
 

--- a/src/liquid_parquet/src/cache/store.rs
+++ b/src/liquid_parquet/src/cache/store.rs
@@ -327,8 +327,8 @@ mod tests {
         policies::{CachePolicy, LruPolicy},
         utils::{create_cache_store, create_entry_id, create_test_array},
     };
+    use crate::sync::thread;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::thread;
 
     use arrow::array::Array;
     use liquid_cache_common::LiquidCacheMode;

--- a/src/liquid_parquet/src/cache/utils.rs
+++ b/src/liquid_parquet/src/cache/utils.rs
@@ -90,7 +90,7 @@ impl From<usize> for CacheEntryID {
 
 impl From<&CacheEntryID> for usize {
     fn from(id: &CacheEntryID) -> Self {
-        unsafe { std::mem::transmute(id) }
+        unsafe { std::mem::transmute(*id) }
     }
 }
 

--- a/src/liquid_parquet/src/cache/utils.rs
+++ b/src/liquid_parquet/src/cache/utils.rs
@@ -72,6 +72,34 @@ pub struct CacheEntryID {
     batch_id: BatchID,
 }
 
+impl From<CacheEntryID> for usize {
+    fn from(id: CacheEntryID) -> Self {
+        unsafe { std::mem::transmute(id) }
+    }
+}
+
+impl From<usize> for CacheEntryID {
+    fn from(value: usize) -> Self {
+        debug_assert_eq!(std::mem::size_of::<Self>(), std::mem::size_of::<usize>());
+        debug_assert_eq!(std::mem::align_of::<Self>(), std::mem::align_of::<usize>());
+        unsafe { std::mem::transmute(value) }
+    }
+}
+
+impl From<&CacheEntryID> for usize {
+    fn from(id: &CacheEntryID) -> Self {
+        unsafe { std::mem::transmute(id) }
+    }
+}
+
+impl From<&usize> for CacheEntryID {
+    fn from(value: &usize) -> Self {
+        debug_assert_eq!(std::mem::size_of::<Self>(), std::mem::size_of::<usize>());
+        debug_assert_eq!(std::mem::align_of::<Self>(), std::mem::align_of::<usize>());
+        unsafe { std::mem::transmute(value) }
+    }
+}
+
 impl CacheEntryID {
     pub fn row_group_id(&self) -> u16 {
         self.rg_id

--- a/src/liquid_parquet/src/reader/runtime/reader/cached_array_reader.rs
+++ b/src/liquid_parquet/src/reader/runtime/reader/cached_array_reader.rs
@@ -2,7 +2,7 @@ use std::{any::Any, collections::VecDeque};
 
 use ahash::AHashMap;
 use arrow::{
-    array::{ArrayRef, BooleanArray, BooleanBufferBuilder, new_empty_array},
+    array::{new_empty_array, ArrayRef, BooleanArray, BooleanBufferBuilder},
     buffer::BooleanBuffer,
 };
 use arrow_schema::{DataType, Field, Fields};
@@ -647,11 +647,9 @@ mod tests {
     }
 
     fn assert_not_contains(cache: &LiquidCachedColumnRef, id: usize) {
-        assert!(
-            cache
-                .get_arrow_array_test_only(BatchID::from_row_id(id, BATCH_SIZE))
-                .is_none()
-        );
+        assert!(cache
+            .get_arrow_array_test_only(BatchID::from_row_id(id, BATCH_SIZE))
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
* Uses Congee (ART) in place of using a hashmap for CachedBatches lookups
* Should improve is_cached lookup performance

Closes https://github.com/XiangpengHao/liquid-cache/issues/181

Flamegraph with partitioned hash table:

![pht](https://github.com/user-attachments/assets/a00622a3-fffd-4c05-abde-b8a3313a81c5)

Flamegraph with ART:

![art](https://github.com/user-attachments/assets/7fd8e1ab-f7bd-40fb-a8d3-f837a776b910)
