### PR TITLE
fix lru policy which may advice evicting the same entry twice.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,10 @@
 			"env": {
 				"RUST_LOG": "info"
 			},
-			"args": [],
+			"args": [
+				"--max-cache-mb",
+				"10"
+			],
 			"cwd": "${workspaceFolder}",
 		},
 		{

--- a/src/liquid_parquet/src/cache/mod.rs
+++ b/src/liquid_parquet/src/cache/mod.rs
@@ -549,7 +549,7 @@ impl LiquidCache {
         cache_mode: LiquidCacheMode,
     ) -> Self {
         assert!(batch_size.is_power_of_two());
-        let cache_policy = Box::new(policies::LruPolicy::new());
+        let cache_policy = Box::new(policies::DiscardPolicy);
 
         LiquidCache {
             files: Mutex::new(AHashMap::new()),

--- a/src/liquid_parquet/src/cache/mod.rs
+++ b/src/liquid_parquet/src/cache/mod.rs
@@ -549,7 +549,7 @@ impl LiquidCache {
         cache_mode: LiquidCacheMode,
     ) -> Self {
         assert!(batch_size.is_power_of_two());
-        let cache_policy = Box::new(policies::DiscardPolicy);
+        let cache_policy = Box::new(policies::LruPolicy::new());
 
         LiquidCache {
             files: Mutex::new(AHashMap::new()),

--- a/src/liquid_parquet/src/cache/store.rs
+++ b/src/liquid_parquet/src/cache/store.rs
@@ -251,8 +251,8 @@ impl CacheStore {
             crate::utils::yield_now_if_shuttle();
 
             loop_count += 1;
-            if loop_count > 10 {
-                log::warn!("Cache store insert looped 10 times");
+            if loop_count > 20 {
+                log::warn!("Cache store insert looped 20 times");
             }
         }
     }

--- a/src/liquid_parquet/src/cache/store.rs
+++ b/src/liquid_parquet/src/cache/store.rs
@@ -203,7 +203,6 @@ impl CacheStore {
                 self.write_to_disk(&to_evict, &liquid_array);
                 self.insert_inner(to_evict, CachedBatch::OnDiskLiquid)
                     .expect("failed to insert on disk liquid");
-                self.policy.notify_evict(&to_evict);
                 Some(not_inserted)
             }
             CacheAdvice::TranscodeToDisk(to_transcode) => {
@@ -400,8 +399,6 @@ mod tests {
                 AdviceType::TranscodeToDisk => CacheAdvice::TranscodeToDisk(*entry_id),
             }
         }
-
-        fn notify_evict(&self, _entry_id: &CacheEntryID) {}
     }
 
     #[test]


### PR DESCRIPTION
A concurrency bug causing two threads evicting the same entry, corrupting the on disk data