### PR TITLE
Inprocess mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,7 @@ dependencies = [
  "futures",
  "liquid-cache-client",
  "liquid-cache-common",
+ "liquid-cache-parquet",
  "liquid-cache-server",
  "log",
  "object_store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "fastrace-futures",
  "fsst-rs",
  "futures",
+ "insta",
  "itertools 0.14.0",
  "liquid-cache-common",
  "log",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,11 +11,16 @@ path = "example_server.rs"
 name = "example_client"
 path = "example_client.rs"
 
+[[bin]]
+name = "example_inprocess"
+path = "example_inprocess.rs"
+
 [dependencies]
 datafusion = { workspace = true }
 liquid-cache-server = { workspace = true }
 liquid-cache-client = { workspace = true }
 liquid-cache-common = { workspace = true }
+liquid-cache-parquet = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }

--- a/examples/example_inprocess.rs
+++ b/examples/example_inprocess.rs
@@ -1,0 +1,26 @@
+use datafusion::prelude::SessionConfig;
+use liquid_cache_parquet::{
+    LiquidCacheInProcessBuilder,
+    common::{CacheEvictionStrategy, LiquidCacheMode},
+};
+use tempfile::TempDir;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new().unwrap();
+
+    let ctx = LiquidCacheInProcessBuilder::new()
+        .with_max_cache_bytes(1024 * 1024 * 1024) // 1GB
+        .with_cache_dir(temp_dir.path().to_path_buf())
+        .with_cache_mode(LiquidCacheMode::Liquid {
+            transcode_in_background: true,
+        })
+        .with_cache_strategy(CacheEvictionStrategy::Discard)
+        .build(SessionConfig::new())?;
+
+    ctx.register_parquet("hits", "examples/nano_hits.parquet", Default::default())
+        .await?;
+
+    ctx.sql("SELECT COUNT(*) FROM hits").await?.show().await?;
+    Ok(())
+}

--- a/src/liquid_parquet/Cargo.toml
+++ b/src/liquid_parquet/Cargo.toml
@@ -38,6 +38,7 @@ rand = "0.9.1"
 shuttle = "0.8.0"
 tracing-subscriber = "0.3.19"
 paste = "1.0.15"
+insta = { version = "1.43.1" }
 
 [features]
 shuttle = []

--- a/src/liquid_parquet/src/cache/mod.rs
+++ b/src/liquid_parquet/src/cache/mod.rs
@@ -341,13 +341,13 @@ impl LiquidCachedColumn {
         }
 
         match self.cache_mode() {
-            LiquidCacheMode::InMemoryArrow => {
+            LiquidCacheMode::Arrow => {
                 let entry_id = self.entry_id(batch_id);
                 self.cache_store
                     .insert(entry_id, CachedBatch::ArrowMemory(array.clone()));
                 Ok(())
             }
-            LiquidCacheMode::InMemoryLiquid {
+            LiquidCacheMode::Liquid {
                 transcode_in_background,
             } => {
                 if *transcode_in_background {

--- a/src/liquid_parquet/src/cache/policies.rs
+++ b/src/liquid_parquet/src/cache/policies.rs
@@ -220,7 +220,7 @@ impl CachePolicy for DiscardPolicy {
 
 fn fallback_advice(entry_id: &CacheEntryID, cache_mode: &LiquidCacheMode) -> CacheAdvice {
     match cache_mode {
-        LiquidCacheMode::InMemoryArrow => CacheAdvice::Discard,
+        LiquidCacheMode::Arrow => CacheAdvice::Discard,
         _ => CacheAdvice::TranscodeToDisk(*entry_id),
     }
 }
@@ -248,12 +248,12 @@ mod test {
         expect_evict: CacheEntryID,
         trigger_entry: CacheEntryID,
     ) {
-        let advice = policy.advise(&trigger_entry, &LiquidCacheMode::InMemoryArrow);
+        let advice = policy.advise(&trigger_entry, &LiquidCacheMode::Arrow);
         assert_eq!(advice, CacheAdvice::Evict(expect_evict));
     }
 
     fn assert_discard_advice(policy: &LruPolicy, trigger_entry: CacheEntryID) {
-        let advice = policy.advise(&trigger_entry, &LiquidCacheMode::InMemoryArrow);
+        let advice = policy.advise(&trigger_entry, &LiquidCacheMode::Arrow);
         assert_eq!(advice, CacheAdvice::Discard);
     }
 
@@ -389,8 +389,8 @@ mod test {
         }
         policy.notify_access(&entry(2));
         policy.notify_access(&entry(5));
-        policy.advise(&entry(0), &LiquidCacheMode::InMemoryArrow);
-        policy.advise(&entry(1), &LiquidCacheMode::InMemoryArrow);
+        policy.advise(&entry(0), &LiquidCacheMode::Arrow);
+        policy.advise(&entry(1), &LiquidCacheMode::Arrow);
 
         let state = policy.state.lock().unwrap();
         state.check_integrity();
@@ -431,7 +431,7 @@ mod test {
             let advised_entries_clone = advised_entries.clone();
 
             let handle = thread::spawn(move || {
-                let advice = policy_clone.advise(&entry(999), &LiquidCacheMode::InMemoryArrow);
+                let advice = policy_clone.advise(&entry(999), &LiquidCacheMode::Arrow);
                 if let CacheAdvice::Evict(entry_id) = advice {
                     let mut entries = advised_entries_clone.lock().unwrap();
                     entries.push(entry_id);
@@ -518,7 +518,7 @@ mod test {
                                 // Evict some earlier entries we created
                                 let to_evict =
                                     entry((thread_id * operations_per_thread + i - 20) as u64);
-                                policy_clone.advise(&to_evict, &LiquidCacheMode::InMemoryArrow);
+                                policy_clone.advise(&to_evict, &LiquidCacheMode::Arrow);
                                 total_evictions_clone.fetch_add(1, Ordering::SeqCst);
                             }
                         }

--- a/src/liquid_parquet/src/cache/stats.rs
+++ b/src/liquid_parquet/src/cache/stats.rs
@@ -181,7 +181,7 @@ mod tests {
             1024,
             usize::MAX,
             tmp_dir.path().to_path_buf(),
-            LiquidCacheMode::InMemoryArrow,
+            LiquidCacheMode::Arrow,
             Box::new(DiscardPolicy::default()),
         );
         let array = Arc::new(arrow::array::Int32Array::from(vec![1, 2, 3]));

--- a/src/liquid_parquet/src/cache/utils.rs
+++ b/src/liquid_parquet/src/cache/utils.rs
@@ -247,7 +247,7 @@ pub(crate) fn create_cache_store(
         batch_size,
         max_cache_bytes,
         temp_dir.keep(),
-        LiquidCacheMode::InMemoryLiquid {
+        LiquidCacheMode::Liquid {
             transcode_in_background: false,
         },
         policy,

--- a/src/liquid_parquet/src/inprocess.rs
+++ b/src/liquid_parquet/src/inprocess.rs
@@ -1,0 +1,651 @@
+use std::any::Any;
+use std::fmt::Formatter;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::array::RecordBatch;
+use arrow_schema::SchemaRef;
+use datafusion::common::Statistics;
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::config::ConfigOptions;
+use datafusion::datasource::physical_plan::{FileScanConfig, ParquetSource};
+use datafusion::datasource::schema_adapter::{DefaultSchemaAdapterFactory, SchemaMapper};
+use datafusion::datasource::source::{DataSource, DataSourceExec};
+use datafusion::error::Result;
+use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, Distribution, ExecutionPlan, PlanProperties,
+    execution_plan::CardinalityEffect,
+    metrics::{ExecutionPlanMetricsSet, MetricsSet},
+    projection::ProjectionExec,
+};
+use datafusion::prelude::{SessionConfig, SessionContext};
+use futures::{Stream, StreamExt};
+use liquid_cache_common::{CacheEvictionStrategy, LiquidCacheMode, coerce_to_liquid_cache_types};
+
+use crate::cache::policies::CachePolicy;
+use crate::{LiquidCache, LiquidCacheRef, LiquidParquetSource};
+
+/// Builder for in-process liquid cache session context
+///
+/// This allows you to use liquid cache within the same process,
+/// instead of using the client-server architecture as in the default mode.
+///
+/// # Example
+/// ```rust
+/// use liquid_cache_parquet::{
+///     common::{CacheEvictionStrategy, LiquidCacheMode},
+///     LiquidCacheInProcessBuilder,
+/// };
+/// use datafusion::prelude::{SessionConfig, SessionContext};
+/// use tempfile::TempDir;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let temp_dir = TempDir::new().unwrap();
+///
+///     let ctx = LiquidCacheInProcessBuilder::new()
+///         .with_max_cache_bytes(1024 * 1024 * 1024) // 1GB
+///         .with_cache_dir(temp_dir.path().to_path_buf())
+///         .with_cache_mode(LiquidCacheMode::InMemoryLiquid { transcode_in_background: false })
+///         .with_cache_strategy(CacheEvictionStrategy::Discard)
+///         .build(SessionConfig::new())?;
+///
+///     // Register the test parquet file
+///     ctx.register_parquet("hits", "../../examples/nano_hits.parquet", Default::default())
+///         .await?;
+///
+///     ctx.sql("SELECT COUNT(*) FROM hits").await?.show().await?;
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct LiquidCacheInProcessBuilder {
+    /// Size of batches for caching
+    batch_size: usize,
+    /// Maximum cache size in bytes
+    max_cache_bytes: usize,
+    /// Directory for disk cache
+    cache_dir: PathBuf,
+    /// Cache mode (InMemoryArrow or InMemoryLiquid)
+    cache_mode: LiquidCacheMode,
+    /// Cache eviction strategy
+    cache_strategy: CacheEvictionStrategy,
+}
+
+impl Default for LiquidCacheInProcessBuilder {
+    fn default() -> Self {
+        Self {
+            batch_size: 8192 * 2,
+            max_cache_bytes: 1024 * 1024 * 1024, // 1GB
+            cache_dir: std::env::temp_dir().join("liquid_cache"),
+            cache_mode: LiquidCacheMode::default(),
+            cache_strategy: CacheEvictionStrategy::Discard,
+        }
+    }
+}
+
+impl LiquidCacheInProcessBuilder {
+    /// Create a new builder with defaults
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set batch size
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Set maximum cache size in bytes
+    pub fn with_max_cache_bytes(mut self, max_cache_bytes: usize) -> Self {
+        self.max_cache_bytes = max_cache_bytes;
+        self
+    }
+
+    /// Set cache directory
+    pub fn with_cache_dir(mut self, cache_dir: PathBuf) -> Self {
+        self.cache_dir = cache_dir;
+        self
+    }
+
+    /// Set cache mode
+    pub fn with_cache_mode(mut self, cache_mode: LiquidCacheMode) -> Self {
+        self.cache_mode = cache_mode;
+        self
+    }
+
+    /// Set cache strategy
+    pub fn with_cache_strategy(mut self, cache_strategy: CacheEvictionStrategy) -> Self {
+        self.cache_strategy = cache_strategy;
+        self
+    }
+
+    /// Build a SessionContext with liquid cache configured
+    pub fn build(self, mut config: SessionConfig) -> Result<SessionContext> {
+        config.options_mut().execution.parquet.pushdown_filters = true;
+        config
+            .options_mut()
+            .execution
+            .parquet
+            .schema_force_view_types = false;
+        config.options_mut().execution.parquet.binary_as_string = true;
+        config.options_mut().execution.batch_size = self.batch_size;
+
+        // Create the cache
+        let policy: Box<dyn CachePolicy> = match self.cache_strategy {
+            CacheEvictionStrategy::Discard => Box::new(crate::policies::DiscardPolicy),
+            CacheEvictionStrategy::Lru => Box::new(crate::policies::LruPolicy::new()),
+            CacheEvictionStrategy::Filo => Box::new(crate::policies::FiloPolicy::new()),
+        };
+        let cache = LiquidCache::new(
+            self.batch_size,
+            self.max_cache_bytes,
+            self.cache_dir,
+            self.cache_mode,
+            policy,
+        );
+        let cache_ref = Arc::new(cache);
+
+        // Create the optimizer
+        let optimizer = InProcessOptimizer::with_cache(cache_ref);
+
+        // Build the session state with the optimizer
+        let state = datafusion::execution::SessionStateBuilder::new()
+            .with_config(config)
+            .with_default_features()
+            .with_physical_optimizer_rule(Arc::new(optimizer))
+            .build();
+
+        Ok(SessionContext::new_with_state(state))
+    }
+}
+
+/// Execution plan that wraps a DataSourceExec with liquid cache and handles schema adaptation
+#[derive(Debug)]
+pub struct InProcessLiquidCacheExec {
+    /// The wrapped execution plan (DataSourceExec with LiquidParquetSource)
+    wrapped_plan: Arc<dyn ExecutionPlan>,
+    /// The original schema that parent nodes expect
+    original_schema: SchemaRef,
+    /// Metrics for this execution plan
+    metrics: ExecutionPlanMetricsSet,
+    /// Plan properties with the original schema
+    plan_properties: PlanProperties,
+}
+
+impl InProcessLiquidCacheExec {
+    /// Create a new InProcessLiquidCacheExec
+    pub fn new(wrapped_plan: Arc<dyn ExecutionPlan>, original_schema: SchemaRef) -> Self {
+        use datafusion::physical_expr::EquivalenceProperties;
+
+        // Create equivalence properties with the original schema
+        let eq_properties = EquivalenceProperties::new(original_schema.clone());
+
+        // Get properties from wrapped plan but use our schema
+        let wrapped_props = wrapped_plan.properties();
+        let plan_properties = PlanProperties::new(
+            eq_properties,
+            wrapped_props.output_partitioning().clone(),
+            wrapped_props.emission_type,
+            wrapped_props.boundedness,
+        );
+
+        Self {
+            wrapped_plan,
+            original_schema,
+            metrics: ExecutionPlanMetricsSet::new(),
+            plan_properties,
+        }
+    }
+}
+
+impl DisplayAs for InProcessLiquidCacheExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "InProcessLiquidCacheExec")
+            }
+            DisplayFormatType::TreeRender => {
+                write!(f, "InProcessLiquidCache")
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for InProcessLiquidCacheExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "InProcessLiquidCacheExec"
+    }
+
+    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.wrapped_plan]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(Self::new(
+            children.into_iter().next().unwrap(),
+            self.original_schema.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let wrapped_stream = self.wrapped_plan.execute(partition, context)?;
+        let original_schema = self.original_schema.clone();
+
+        Ok(Box::pin(SchemaAdaptingStream::new(
+            wrapped_stream,
+            original_schema,
+        )))
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        self.wrapped_plan.statistics()
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        self.wrapped_plan.required_input_distribution()
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        self.wrapped_plan.benefits_from_input_partitioning()
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        self.wrapped_plan.supports_limit_pushdown()
+    }
+
+    fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>> {
+        self.wrapped_plan.with_fetch(limit).map(|new_wrapped| {
+            Arc::new(Self::new(new_wrapped, self.original_schema.clone())) as Arc<dyn ExecutionPlan>
+        })
+    }
+
+    fn fetch(&self) -> Option<usize> {
+        self.wrapped_plan.fetch()
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        self.wrapped_plan.cardinality_effect()
+    }
+
+    fn try_swapping_with_projection(
+        &self,
+        projection: &ProjectionExec,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        self.wrapped_plan.try_swapping_with_projection(projection)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+}
+
+/// Stream that adapts schema from liquid cache types back to original types
+struct SchemaAdaptingStream {
+    wrapped_stream: SendableRecordBatchStream,
+    original_schema: SchemaRef,
+    schema_mapper: Option<Arc<dyn SchemaMapper>>,
+}
+
+impl SchemaAdaptingStream {
+    fn new(wrapped_stream: SendableRecordBatchStream, original_schema: SchemaRef) -> Self {
+        Self {
+            wrapped_stream,
+            original_schema,
+            schema_mapper: None,
+        }
+    }
+}
+
+impl Stream for SchemaAdaptingStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.wrapped_stream.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                let adapted_batch = if let Some(schema_mapper) = &self.schema_mapper {
+                    schema_mapper.map_batch(batch).unwrap()
+                } else {
+                    // Create schema mapper on first batch
+                    let (schema_mapper, _) =
+                        DefaultSchemaAdapterFactory::from_schema(self.original_schema.clone())
+                            .map_schema(&batch.schema())
+                            .unwrap();
+                    let adapted_batch = schema_mapper.map_batch(batch).unwrap();
+                    self.schema_mapper = Some(schema_mapper);
+                    adapted_batch
+                };
+                Poll::Ready(Some(Ok(adapted_batch)))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl RecordBatchStream for SchemaAdaptingStream {
+    fn schema(&self) -> SchemaRef {
+        self.original_schema.clone()
+    }
+}
+
+/// Physical optimizer rule for in-process liquid cache
+///
+/// This optimizer rewrites DataSourceExec nodes that read Parquet files
+/// to use LiquidParquetSource instead of the default ParquetSource
+#[derive(Debug)]
+pub struct InProcessOptimizer {
+    cache: LiquidCacheRef,
+}
+
+impl InProcessOptimizer {
+    /// Create an optimizer with an existing cache instance
+    pub fn with_cache(cache: LiquidCacheRef) -> Self {
+        Self { cache }
+    }
+
+    /// Rewrite a data source plan to use liquid cache
+    fn rewrite_data_source_plan(&self, plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let cache_mode = self.cache.cache_mode();
+
+        let rewritten = plan
+            .transform_up(|node| {
+                let any_plan = node.as_any();
+                if let Some(plan) = any_plan.downcast_ref::<DataSourceExec>() {
+                    let data_source = plan.data_source();
+                    let any_source = data_source.as_any();
+                    if let Some(file_scan_config) = any_source.downcast_ref::<FileScanConfig>() {
+                        let file_source = file_scan_config.file_source();
+                        let any_file_source = file_source.as_any();
+
+                        // Check if this is a ParquetSource (same logic as server code)
+                        if let Some(parquet_source) =
+                            any_file_source.downcast_ref::<ParquetSource>()
+                        {
+                            // Save the original schema before coercion
+                            let original_schema = plan.schema();
+
+                            // Create a new LiquidParquetSource from the existing ParquetSource
+                            let liquid_source = LiquidParquetSource::from_parquet_source(
+                                parquet_source.clone(),
+                                file_scan_config.file_schema.clone(),
+                                self.cache.clone(),
+                                *cache_mode,
+                            );
+
+                            let mut new_config = file_scan_config.clone();
+                            new_config.file_source = Arc::new(liquid_source);
+
+                            // Coerce schema types for liquid cache compatibility
+                            let coerced_schema = coerce_to_liquid_cache_types(
+                                new_config.file_schema.as_ref(),
+                                cache_mode,
+                            );
+
+                            new_config.file_schema = Arc::new(coerced_schema);
+
+                            let new_data_source: Arc<dyn DataSource> = Arc::new(new_config);
+                            let wrapped_plan = Arc::new(DataSourceExec::new(new_data_source));
+
+                            // Wrap with InProcessLiquidCacheExec to handle schema adaptation
+                            let adapter_plan = Arc::new(InProcessLiquidCacheExec::new(
+                                wrapped_plan,
+                                original_schema,
+                            ));
+
+                            // Stop recursion since we've rewritten the data source
+                            return Ok(Transformed::new(
+                                adapter_plan,
+                                true,
+                                TreeNodeRecursion::Stop,
+                            ));
+                        }
+                    }
+                }
+                Ok(Transformed::no(node))
+            })
+            .unwrap();
+
+        rewritten.data
+    }
+}
+
+impl PhysicalOptimizerRule for InProcessOptimizer {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(self.rewrite_data_source_plan(plan))
+    }
+
+    fn name(&self) -> &str {
+        "InProcessLiquidCacheOptimizer"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    use arrow::util::pretty::pretty_format_batches;
+    use datafusion::{
+        physical_plan::{ExecutionPlan, collect},
+        prelude::{ParquetReadOptions, SessionConfig, SessionContext},
+    };
+    use liquid_cache_common::LiquidCacheMode;
+
+    const TEST_FILE: &str = "../../examples/nano_hits.parquet";
+
+    #[test]
+    fn test_builder_pattern() {
+        let temp_dir = TempDir::new().unwrap();
+        let _builder = LiquidCacheInProcessBuilder::new()
+            .with_batch_size(4096)
+            .with_max_cache_bytes(512 * 1024 * 1024)
+            .with_cache_dir(temp_dir.path().to_path_buf())
+            .with_cache_strategy(CacheEvictionStrategy::Lru);
+
+        // Test that we can build a SessionContext
+        let session_config = SessionConfig::new();
+        let ctx = _builder.build(session_config).unwrap();
+        assert!(ctx.state().physical_optimizers().len() > 0);
+    }
+
+    #[test]
+    fn test_session_context_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let builder =
+            LiquidCacheInProcessBuilder::new().with_cache_dir(temp_dir.path().to_path_buf());
+
+        let session_config = SessionConfig::new();
+        let ctx = builder.build(session_config).unwrap();
+
+        // Verify that the session context has been created successfully
+        assert!(ctx.state().physical_optimizers().len() > 0);
+    }
+
+    async fn create_session_context_with_liquid_cache(
+        cache_mode: LiquidCacheMode,
+        cache_size_bytes: usize,
+    ) -> Result<SessionContext> {
+        let temp_dir = TempDir::new().unwrap();
+
+        let ctx = LiquidCacheInProcessBuilder::new()
+            .with_max_cache_bytes(cache_size_bytes)
+            .with_cache_dir(temp_dir.path().to_path_buf())
+            .with_cache_mode(cache_mode)
+            .with_cache_strategy(CacheEvictionStrategy::Discard)
+            .build(SessionConfig::new())?;
+
+        // Register the test parquet file
+        ctx.register_parquet("hits", TEST_FILE, ParquetReadOptions::default())
+            .await
+            .unwrap();
+
+        Ok(ctx)
+    }
+
+    async fn get_physical_plan(sql: &str, ctx: &SessionContext) -> Arc<dyn ExecutionPlan> {
+        let df = ctx.sql(sql).await.unwrap();
+        let (state, plan) = df.into_parts();
+        state.create_physical_plan(&plan).await.unwrap()
+    }
+
+    async fn run_sql_with_cache(
+        sql: &str,
+        cache_mode: LiquidCacheMode,
+        cache_size_bytes: usize,
+    ) -> String {
+        let ctx = create_session_context_with_liquid_cache(cache_mode, cache_size_bytes)
+            .await
+            .unwrap();
+
+        async fn get_result(ctx: &SessionContext, sql: &str) -> String {
+            let plan = get_physical_plan(sql, ctx).await;
+            let batches = collect(plan, ctx.task_ctx()).await.unwrap();
+            pretty_format_batches(&batches).unwrap().to_string()
+        }
+
+        // Run the query twice to test caching behavior
+        let first_run = get_result(&ctx, sql).await;
+        let second_run = get_result(&ctx, sql).await;
+
+        // Results should be identical
+        assert_eq!(first_run, second_run);
+
+        first_run
+    }
+
+    async fn test_runner(sql: &str, reference: &str) {
+        let cache_modes = [
+            LiquidCacheMode::Arrow,
+            LiquidCacheMode::Liquid {
+                transcode_in_background: false,
+            },
+            LiquidCacheMode::Liquid {
+                transcode_in_background: true,
+            },
+        ];
+
+        // Test different cache sizes: small, medium, and unlimited
+        let cache_sizes = [10 * 1024, 1024 * 1024, usize::MAX]; // 10KB, 1MB, unlimited
+
+        for cache_mode in cache_modes {
+            for cache_size in cache_sizes {
+                let result = run_sql_with_cache(sql, cache_mode, cache_size).await;
+                assert_eq!(
+                    result, reference,
+                    "Results differ for cache_mode: {:?}, cache_size: {}",
+                    cache_mode, cache_size
+                );
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_url_prefix_filtering() {
+        let sql = r#"select COUNT(*) from hits where "URL" like 'https://%'"#;
+        let reference = run_sql_with_cache(
+            sql,
+            LiquidCacheMode::Liquid {
+                transcode_in_background: false,
+            },
+            1024 * 1024,
+        )
+        .await;
+
+        // Test across different cache configurations
+        test_runner(sql, &reference).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_url_selection_and_ordering() {
+        let sql = r#"select "URL" from hits where "URL" like '%tours%' order by "URL" desc"#;
+        let reference = run_sql_with_cache(
+            sql,
+            LiquidCacheMode::Liquid {
+                transcode_in_background: false,
+            },
+            1024 * 1024,
+        )
+        .await;
+
+        test_runner(sql, &reference).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_os_selection() {
+        let sql = r#"select "OS" from hits where "URL" like '%tours%' order by "OS" desc"#;
+        let reference = run_sql_with_cache(
+            sql,
+            LiquidCacheMode::Liquid {
+                transcode_in_background: false,
+            },
+            1024 * 1024,
+        )
+        .await;
+
+        test_runner(sql, &reference).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_referer_filtering() {
+        let sql = r#"select "Referer" from hits where "Referer" <> '' AND "URL" like '%tours%' order by "Referer" desc"#;
+        let reference = run_sql_with_cache(
+            sql,
+            LiquidCacheMode::Liquid {
+                transcode_in_background: false,
+            },
+            1024 * 1024,
+        )
+        .await;
+
+        test_runner(sql, &reference).await;
+    }
+
+    #[tokio::test]
+    async fn test_session_context_with_cache_stats() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let session_config = SessionConfig::new();
+        let _ctx = LiquidCacheInProcessBuilder::new()
+            .with_cache_dir(temp_dir.path().to_path_buf())
+            .with_max_cache_bytes(1024 * 1024) // 1MB cache
+            .build(session_config)
+            .unwrap();
+
+        // Verify that the session context was created successfully
+        // In a real scenario, we would access cache stats through the session context
+        // but for this test, we just verify the builder works
+        assert!(true);
+    }
+}

--- a/src/liquid_parquet/src/lib.rs
+++ b/src/liquid_parquet/src/lib.rs
@@ -12,6 +12,11 @@ pub use reader::LiquidPredicate;
 pub(crate) mod utils;
 pub use utils::boolean_buffer_and_then;
 
+mod inprocess;
+pub use inprocess::LiquidCacheInProcessBuilder;
+
+pub use liquid_cache_common as common;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 #[allow(unused)]
 enum AblationStudyMode {

--- a/src/liquid_parquet/src/lib.rs
+++ b/src/liquid_parquet/src/lib.rs
@@ -11,8 +11,10 @@ pub use reader::LiquidParquetSource;
 pub use reader::LiquidPredicate;
 pub(crate) mod utils;
 pub use utils::boolean_buffer_and_then;
-
 mod inprocess;
+#[cfg(test)]
+mod tests;
+
 pub use inprocess::LiquidCacheInProcessBuilder;
 
 pub use liquid_cache_common as common;

--- a/src/liquid_parquet/src/reader/runtime/reader/cached_array_reader.rs
+++ b/src/liquid_parquet/src/reader/runtime/reader/cached_array_reader.rs
@@ -453,7 +453,7 @@ mod tests {
             BATCH_SIZE,
             usize::MAX,
             tmp_dir.path().to_path_buf(),
-            LiquidCacheMode::InMemoryLiquid {
+            LiquidCacheMode::Liquid {
                 transcode_in_background: false,
             },
             Box::new(DiscardPolicy::default()),

--- a/src/liquid_parquet/src/reader/runtime/reader/tests.rs
+++ b/src/liquid_parquet/src/reader/runtime/reader/tests.rs
@@ -169,11 +169,11 @@ async fn basic_stuff(cache_mode: &LiquidCacheMode) {
 }
 
 const CACHE_MODES: &[LiquidCacheMode] = &[
-    LiquidCacheMode::InMemoryArrow,
-    LiquidCacheMode::InMemoryLiquid {
+    LiquidCacheMode::Arrow,
+    LiquidCacheMode::Liquid {
         transcode_in_background: false,
     },
-    LiquidCacheMode::InMemoryLiquid {
+    LiquidCacheMode::Liquid {
         transcode_in_background: true,
     },
 ];
@@ -353,7 +353,7 @@ async fn test_reading_with_full_cache() {
         batch_size,
         1,
         tmp_dir.path().to_path_buf(),
-        LiquidCacheMode::InMemoryLiquid {
+        LiquidCacheMode::Liquid {
             transcode_in_background: false,
         },
         Box::new(DiscardPolicy::default()),

--- a/src/liquid_parquet/src/tests/mod.rs
+++ b/src/liquid_parquet/src/tests/mod.rs
@@ -1,0 +1,163 @@
+use std::sync::Arc;
+use tempfile::TempDir;
+
+use arrow::util::pretty::pretty_format_batches;
+use datafusion::{
+    error::Result,
+    physical_plan::{ExecutionPlan, collect, display::DisplayableExecutionPlan},
+    prelude::{ParquetReadOptions, SessionConfig, SessionContext},
+};
+use liquid_cache_common::{CacheEvictionStrategy, LiquidCacheMode};
+
+use crate::LiquidCacheInProcessBuilder;
+
+const TEST_FILE: &str = "../../examples/nano_hits.parquet";
+
+async fn create_session_context_with_liquid_cache(
+    cache_mode: LiquidCacheMode,
+    cache_size_bytes: usize,
+) -> Result<SessionContext> {
+    let temp_dir = TempDir::new().unwrap();
+
+    let ctx = LiquidCacheInProcessBuilder::new()
+        .with_max_cache_bytes(cache_size_bytes)
+        .with_cache_dir(temp_dir.path().to_path_buf())
+        .with_cache_mode(cache_mode)
+        .with_cache_strategy(CacheEvictionStrategy::Discard)
+        .build(SessionConfig::new())?;
+
+    // Register the test parquet file
+    ctx.register_parquet("hits", TEST_FILE, ParquetReadOptions::default())
+        .await
+        .unwrap();
+
+    Ok(ctx)
+}
+
+async fn get_physical_plan(sql: &str, ctx: &SessionContext) -> Arc<dyn ExecutionPlan> {
+    let df = ctx.sql(sql).await.unwrap();
+    let (state, plan) = df.into_parts();
+    state.create_physical_plan(&plan).await.unwrap()
+}
+
+async fn run_sql_with_cache(
+    sql: &str,
+    cache_mode: LiquidCacheMode,
+    cache_size_bytes: usize,
+) -> (String, String) {
+    let ctx = create_session_context_with_liquid_cache(cache_mode, cache_size_bytes)
+        .await
+        .unwrap();
+
+    let plan = get_physical_plan(sql, &ctx).await;
+    let displayable = DisplayableExecutionPlan::new(plan.as_ref());
+    let plan_string = format!("{}", displayable.tree_render());
+
+    async fn get_result(ctx: &SessionContext, sql: &str) -> String {
+        let plan = get_physical_plan(sql, ctx).await;
+        let batches = collect(plan, ctx.task_ctx()).await.unwrap();
+        pretty_format_batches(&batches).unwrap().to_string()
+    }
+
+    let first_run = get_result(&ctx, sql).await;
+    let second_run = get_result(&ctx, sql).await;
+
+    assert_eq!(first_run, second_run);
+
+    (first_run, plan_string)
+}
+
+async fn test_runner(sql: &str, reference: &str) {
+    let cache_modes = [
+        LiquidCacheMode::Arrow,
+        LiquidCacheMode::Liquid {
+            transcode_in_background: false,
+        },
+        LiquidCacheMode::Liquid {
+            transcode_in_background: true,
+        },
+    ];
+
+    let cache_sizes = [10 * 1024, 1024 * 1024, usize::MAX]; // 10KB, 1MB, unlimited
+
+    for cache_mode in cache_modes {
+        for cache_size in cache_sizes {
+            let (result, _plan) = run_sql_with_cache(sql, cache_mode, cache_size).await;
+            assert_eq!(
+                result, reference,
+                "Results differ for cache_mode: {:?}, cache_size: {}",
+                cache_mode, cache_size
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_url_prefix_filtering() {
+    let sql = r#"select COUNT(*) from hits where "URL" like 'https://%'"#;
+
+    let (reference, plan) = run_sql_with_cache(
+        sql,
+        LiquidCacheMode::Liquid {
+            transcode_in_background: false,
+        },
+        1024 * 1024,
+    )
+    .await;
+
+    insta::assert_snapshot!(format!("plan: \n{}\nvalues: \n{}", plan, reference));
+    test_runner(sql, &reference).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_url_selection_and_ordering() {
+    let sql = r#"select "URL" from hits where "URL" like '%tours%' order by "URL" desc"#;
+
+    let (reference, plan) = run_sql_with_cache(
+        sql,
+        LiquidCacheMode::Liquid {
+            transcode_in_background: false,
+        },
+        1024 * 1024,
+    )
+    .await;
+
+    insta::assert_snapshot!(format!("plan: \n{}\nvalues: \n{}", plan, reference));
+    test_runner(sql, &reference).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_os_selection() {
+    let sql = r#"select "OS" from hits where "URL" like '%tours%' order by "OS" desc"#;
+
+    let (reference, plan) = run_sql_with_cache(
+        sql,
+        LiquidCacheMode::Liquid {
+            transcode_in_background: false,
+        },
+        1024 * 1024,
+    )
+    .await;
+
+    insta::assert_snapshot!(format!("plan: \n{}\nvalues: \n{}", plan, reference));
+
+    test_runner(sql, &reference).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_referer_filtering() {
+    let sql = r#"select "Referer" from hits where "Referer" <> '' AND "URL" like '%tours%' order by "Referer" desc"#;
+
+    let (reference, plan) = run_sql_with_cache(
+        sql,
+        LiquidCacheMode::Liquid {
+            transcode_in_background: false,
+        },
+        1024 * 1024,
+    )
+    .await;
+
+    insta::assert_snapshot!(format!("plan: \n{}\nvalues: \n{}", plan, reference));
+
+    test_runner(sql, &reference).await;
+}

--- a/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__os_selection.snap
+++ b/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__os_selection.snap
@@ -1,0 +1,40 @@
+---
+source: src/liquid_parquet/src/tests/mod.rs
+expression: "format!(\"plan: \\n{}\\nvalues: \\n{}\", plan, reference)"
+---
+plan: 
+┌───────────────────────────┐
+│          SortExec         │
+│    --------------------   │
+│         OS@0 DESC         │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│  InProcessLiquidCacheExec │
+│    --------------------   │
+│    InProcessLiquidCache   │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│       DataSourceExec      │
+│    --------------------   │
+│          files: 1         │
+│                           │
+│          format:          │
+│       liquid_parquet      │
+└───────────────────────────┘
+
+values: 
++----+
+| OS |
++----+
+| 44 |
+| 44 |
+| 44 |
+| 44 |
+| 44 |
+| 2  |
+| 2  |
+| 2  |
+| 2  |
+| 2  |
+| 2  |
++----+

--- a/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__referer_filtering.snap
+++ b/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__referer_filtering.snap
@@ -1,0 +1,39 @@
+---
+source: src/liquid_parquet/src/tests/mod.rs
+expression: "format!(\"plan: \\n{}\\nvalues: \\n{}\", plan, reference)"
+---
+plan: 
+┌───────────────────────────┐
+│          SortExec         │
+│    --------------------   │
+│       Referer@0 DESC      │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│  InProcessLiquidCacheExec │
+│    --------------------   │
+│    InProcessLiquidCache   │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│       DataSourceExec      │
+│    --------------------   │
+│          files: 1         │
+│                           │
+│          format:          │
+│       liquid_parquet      │
+└───────────────────────────┘
+
+values: 
++---------------------------------------------------------------------------------------------------------+
+| Referer                                                                                                 |
++---------------------------------------------------------------------------------------------------------+
+| https://go.mail/folder-1/online.ru/search?text=скачать из                                               |
+| http://tambov.irr.ru/registrict=2660628&cbv=r2013%2F&ei                                                 |
+| http://tambov.irr.ru/registrict=2660628&cbv=r2013%2F&ei                                                 |
+| http://tambov.irr.ru/registrict=2660628&cbv=r2013%26ev_positions/2/transmittaD3xnA%26ad%3D1%26bid%3D400 |
+| http://tambov.irr.ru/registrict=2660628&cbv=r2013%26ev_pl%3Dh%26utm_source=view.php                     |
+| http://tambov.irr.ru/registrict=2660628&cbv=r2013%26ev_pl%3Dh%26utm_source=view.php                     |
+| http://tambov.irr.ru/filmId=BcVrXpM5UXI&where=any&numphoto                                              |
+| http://tambov.irr.ru/filmId=BcVrXpM5UXI&where=any&numphoto                                              |
+| http://tambov.irr.ru/avtoma-gorod55.ru/cars/micros/out-of-town                                          |
+| http://tambov.irr.ru/avtoma-gorod55.ru/cars/micros/out-of-town                                          |
++---------------------------------------------------------------------------------------------------------+

--- a/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__url_prefix_filtering.snap
+++ b/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__url_prefix_filtering.snap
@@ -1,0 +1,55 @@
+---
+source: src/liquid_parquet/src/tests/mod.rs
+expression: "format!(\"plan: \\n{}\\nvalues: \\n{}\", plan, reference)"
+---
+plan: 
+┌───────────────────────────┐
+│       ProjectionExec      │
+│    --------------------   │
+│         count(*):         │
+│      count(Int64(1))      │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│       AggregateExec       │
+│    --------------------   │
+│       aggr: count(1)      │
+│        mode: Final        │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│   CoalescePartitionsExec  │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│       AggregateExec       │
+│    --------------------   │
+│       aggr: count(1)      │
+│       mode: Partial       │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│      RepartitionExec      │
+│    --------------------   │
+│ partition_count(in->out): │
+│          1 -> 24          │
+│                           │
+│    partitioning_scheme:   │
+│    RoundRobinBatch(24)    │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│  InProcessLiquidCacheExec │
+│    --------------------   │
+│    InProcessLiquidCache   │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│       DataSourceExec      │
+│    --------------------   │
+│          files: 1         │
+│                           │
+│          format:          │
+│       liquid_parquet      │
+└───────────────────────────┘
+
+values: 
++----------+
+| count(*) |
++----------+
+| 23113    |
++----------+

--- a/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__url_selection_and_ordering.snap
+++ b/src/liquid_parquet/src/tests/snapshots/liquid_cache_parquet__tests__url_selection_and_ordering.snap
@@ -1,0 +1,40 @@
+---
+source: src/liquid_parquet/src/tests/mod.rs
+expression: "format!(\"plan: \\n{}\\nvalues: \\n{}\", plan, reference)"
+---
+plan: 
+┌───────────────────────────┐
+│          SortExec         │
+│    --------------------   │
+│         URL@0 DESC        │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│  InProcessLiquidCacheExec │
+│    --------------------   │
+│    InProcessLiquidCache   │
+└─────────────┬─────────────┘
+┌─────────────┴─────────────┐
+│       DataSourceExec      │
+│    --------------------   │
+│          files: 1         │
+│                           │
+│          format:          │
+│       liquid_parquet      │
+└───────────────────────────┘
+
+values: 
++-------------------------------------------------------------------------------------------------------------------------------+
+| URL                                                                                                                           |
++-------------------------------------------------------------------------------------------------------------------------------+
+| https://produkty%2Fpulove.ru/search_terms-vzyat_kobrye-russion/russia/piterators-tourse                                       |
+| https://produkty%2Fpulove.ru/search_terms-vzyat_kobrye-russion/russia/piterators-tourse                                       |
+| https://produkty%2Fpulove.ru/booklyattion-ware/tours.ru                                                                       |
+| https://produkty%2Fpulove.ru/booklyattion-ware/tours.ru                                                                       |
+| https://produkty%2Fpulove.ru/booklyattion-ware/activaro.ru/cars.ru/footours-index.ru/files/item=11497449%26pz%3D0             |
+| https://produkty%2Fpulove.ru/booklyattion-ware/activaro.ru/cars.ru/footours-index.ru/files/item=11497449%26pz%3D0             |
+| https://produkty%2Fpulove.ru/booklyattion-ware/activaro.ru/cars.ru/footours-index.ru/files/item=11497449%26pz%3D0             |
+| https://produkty%2Fpulove.ru/booklyattion-ware/activaro.ru/cars.ru/footours-index.ru/files/item=11497449%26pz%3D0             |
+| https://produkty%2Fplata.ru/filmId=e308f57e213e9eee96bcb752910-widget/tours.ru/product_priznaniya-1-metallic=0&engineVolumeTo |
+| https://produkty%2Fplata.ru/filmId=e308f57e213e9eee96bcb752910-widget/tours.ru/product_priznaniya-1-metallic=0&engineVolumeTo |
+| http://tours/Ekategoriya%2F&sr=http://slovareniye                                                                             |
++-------------------------------------------------------------------------------------------------------------------------------+

--- a/src/server/src/service.rs
+++ b/src/server/src/service.rs
@@ -365,16 +365,16 @@ mod tests {
             .await
             .unwrap();
         let plan = df.create_physical_plan().await.unwrap();
-        rewrite_plan_inner(plan.clone(), &LiquidCacheMode::InMemoryArrow);
+        rewrite_plan_inner(plan.clone(), &LiquidCacheMode::Arrow);
         rewrite_plan_inner(
             plan.clone(),
-            &LiquidCacheMode::InMemoryLiquid {
+            &LiquidCacheMode::Liquid {
                 transcode_in_background: false,
             },
         );
         rewrite_plan_inner(
             plan.clone(),
-            &LiquidCacheMode::InMemoryLiquid {
+            &LiquidCacheMode::Liquid {
                 transcode_in_background: true,
             },
         );


### PR DESCRIPTION
This pr implements a in process mode, which basically allow you to do this:


```rust
use datafusion::prelude::SessionConfig;
use liquid_cache_parquet::{
    LiquidCacheInProcessBuilder,
    common::{CacheEvictionStrategy, LiquidCacheMode},
};
use tempfile::TempDir;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let temp_dir = TempDir::new().unwrap();

    let ctx = LiquidCacheInProcessBuilder::new()
        .with_max_cache_bytes(1024 * 1024 * 1024) // 1GB
        .with_cache_dir(temp_dir.path().to_path_buf())
        .with_cache_mode(LiquidCacheMode::Liquid {
            transcode_in_background: true,
        })
        .with_cache_strategy(CacheEvictionStrategy::Discard)
        .build(SessionConfig::new())?;

    ctx.register_parquet("hits", "examples/nano_hits.parquet", Default::default())
        .await?;

    ctx.sql("SELECT COUNT(*) FROM hits").await?.show().await?;
    Ok(())
}
```

Meaning that you no longer need to setup a server and client. all the caching etc happens within the same process. This provides the highest possible performance, but at the cost of each compute node may need to cache similar data.
