### PR TITLE
Allow writing arrow record batch to disk

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 serde.workspace = true
 sysinfo = { version = "0.35.1", default-features = false, features = [
 	"network",
+	"disk",
 ] }
 object_store = { workspace = true, features = ["http"] }
 bytes = { workspace = true }

--- a/benchmark/tpch/tpch_inprocess.rs
+++ b/benchmark/tpch/tpch_inprocess.rs
@@ -164,7 +164,7 @@ impl TpchInProcessBenchmark {
                 let v = LiquidCacheInProcessBuilder::new()
                     .with_max_cache_bytes(cache_size)
                     .with_cache_mode(LiquidCacheMode::Arrow)
-                    .with_cache_strategy(CacheEvictionStrategy::Discard)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
                     .build(session_config)?;
                 (v.0, Some(v.1))
             }
@@ -174,7 +174,7 @@ impl TpchInProcessBenchmark {
                     .with_cache_mode(LiquidCacheMode::Liquid {
                         transcode_in_background: true,
                     })
-                    .with_cache_strategy(CacheEvictionStrategy::Discard)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
                     .build(session_config)?;
                 (v.0, Some(v.1))
             }
@@ -184,7 +184,7 @@ impl TpchInProcessBenchmark {
                     .with_cache_mode(LiquidCacheMode::Liquid {
                         transcode_in_background: false,
                     })
-                    .with_cache_strategy(CacheEvictionStrategy::Discard)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
                     .build(session_config)?;
                 (v.0, Some(v.1))
             }

--- a/dev/thoughts/artifact-eval.md
+++ b/dev/thoughts/artifact-eval.md
@@ -32,6 +32,6 @@ env RUST_LOG=info,clickbench_client=debug RUST_BACKTRACE=1 RUSTFLAGS='-C target-
 
 ### Start server with limited memory
 ```bash
-systemd-run --scope -p MemoryMax=16G ./target/release/bench_server --address 127.0.0.1:5001 --max-
+echo 1 | sudo tee /proc/sys/vm/drop_caches && systemd-run --scope -p MemoryMax=16G ./target/release/bench_server --address 127.0.0.1:5001 --max-
 cache-mb 12288
 ```

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -35,6 +35,8 @@ pub enum CacheEvictionStrategy {
     Filo,
     /// Least Recently Used
     Lru,
+    /// Write to disk when the cache is full.
+    ToDisk,
 }
 
 impl Display for CacheMode {

--- a/src/liquid_parquet/README.md
+++ b/src/liquid_parquet/README.md
@@ -6,7 +6,7 @@ Learn more about LiquidCache in the [README](https://github.com/XiangpengHao/liq
 
 ## Usage
 
-```rust
+```rust,ignore
 use datafusion::prelude::SessionConfig;
 use liquid_cache_parquet::{
     LiquidCacheInProcessBuilder,
@@ -18,7 +18,7 @@ use tempfile::TempDir;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new().unwrap();
 
-    let ctx = LiquidCacheInProcessBuilder::new()
+    let (ctx, _) = LiquidCacheInProcessBuilder::new()
         .with_max_cache_bytes(1024 * 1024 * 1024) // 1GB
         .with_cache_dir(temp_dir.path().to_path_buf())
         .with_cache_mode(LiquidCacheMode::Liquid {

--- a/src/liquid_parquet/src/cache/stats.rs
+++ b/src/liquid_parquet/src/cache/stats.rs
@@ -125,14 +125,16 @@ impl LiquidCache {
         self.cache_store.for_each_entry(|entry_id, cached_batch| {
             let memory_size = cached_batch.memory_usage_bytes();
             let row_count = match cached_batch {
-                CachedBatch::ArrowMemory(array) => Some(array.len() as u64),
-                CachedBatch::LiquidMemory(array) => Some(array.len() as u64),
-                CachedBatch::OnDiskLiquid => None,
+                CachedBatch::MemoryArrow(array) => Some(array.len() as u64),
+                CachedBatch::MemoryLiquid(array) => Some(array.len() as u64),
+                CachedBatch::DiskLiquid => None,
+                CachedBatch::DiskArrow => None, // We'd need to read it to get the count
             };
             let cache_type = match cached_batch {
-                CachedBatch::ArrowMemory(_) => "InMemory",
-                CachedBatch::LiquidMemory(_) => "LiquidMemory",
-                CachedBatch::OnDiskLiquid => "OnDiskLiquid",
+                CachedBatch::MemoryArrow(_) => "InMemory",
+                CachedBatch::MemoryLiquid(_) => "LiquidMemory",
+                CachedBatch::DiskLiquid => "OnDiskLiquid",
+                CachedBatch::DiskArrow => "OnDiskArrow",
             };
             let reference_count = cached_batch.reference_count();
             writer

--- a/src/liquid_parquet/src/cache/store.rs
+++ b/src/liquid_parquet/src/cache/store.rs
@@ -256,7 +256,7 @@ impl CacheStore {
 
     fn write_liquid_to_disk(&self, entry_id: &CacheEntryID, liquid_array: &LiquidArrayRef) {
         let disk_usage = entry_id
-            .on_disk_liquid_path(self.config.cache_root_dir(), liquid_array)
+            .write_liquid_to_disk(self.config.cache_root_dir(), liquid_array)
             .expect("failed to write liquid to disk");
         self.budget.add_used_disk_bytes(disk_usage);
     }

--- a/src/liquid_parquet/src/cache/store.rs
+++ b/src/liquid_parquet/src/cache/store.rs
@@ -1,6 +1,6 @@
 use congee::CongeeArc;
 use std::fmt::{Debug, Formatter};
-use std::{fs::File, io::Write, path::PathBuf};
+use std::path::PathBuf;
 
 use super::{
     CacheEntryID, CachedBatch, LiquidCompressorStates,
@@ -103,38 +103,6 @@ pub(crate) struct CacheStore {
     compressor_states: CompressorStates,
 }
 
-pub(super) struct MemoryReservation<'a> {
-    reserved_bytes: usize,
-    memory_budget: &'a BudgetAccounting,
-    data: Option<CachedBatch>,
-}
-
-impl<'a> MemoryReservation<'a> {
-    /// Try to fill the reservation with data.
-    /// Returns ok if the data was filled, err if the memory budget is exceeded.
-    pub(super) fn try_fill_data(&mut self, data: CachedBatch) -> Result<(), ()> {
-        let new_memory_size = data.memory_usage_bytes();
-        self.memory_budget
-            .try_update_memory_usage(self.reserved_bytes, new_memory_size)?;
-        self.data = Some(data);
-        Ok(())
-    }
-
-    fn into_inner(mut self) -> CachedBatch {
-        let data = self.data.take();
-        std::mem::forget(self);
-        data.expect("Data was not filled")
-    }
-}
-
-impl<'a> Drop for MemoryReservation<'a> {
-    fn drop(&mut self) {
-        self.memory_budget
-            .try_update_memory_usage(self.reserved_bytes, 0)
-            .expect("Failed to release memory reservation");
-    }
-}
-
 /// Advice given by the cache policy.
 #[derive(PartialEq, Eq, Debug)]
 pub enum CacheAdvice {
@@ -144,6 +112,8 @@ pub enum CacheAdvice {
     TranscodeToDisk(CacheEntryID),
     /// Transcode the entry to liquid memory.
     Transcode(CacheEntryID),
+    /// Write the entry to disk as-is (preserve format).
+    ToDisk(CacheEntryID),
     /// Discard the entry,  do not cache.
     Discard,
 }
@@ -165,25 +135,6 @@ impl CacheStore {
             tracer: CacheTracer::new(),
             compressor_states: CompressorStates::new(),
         }
-    }
-
-    /// Reserve memory in the cache.
-    /// Returns ok if the space was reserved, err if the cache is full.
-    pub(super) fn reserve_memory(&self, size: usize) -> Result<MemoryReservation, ()> {
-        self.budget
-            .try_reserve_memory(size)
-            .map(|_| MemoryReservation {
-                reserved_bytes: size,
-                memory_budget: &self.budget,
-                data: None,
-            })
-    }
-
-    /// Insert a batch into the cache, but reserve the memory first.
-    /// This is useful for cases where the memory usage is known in advance,
-    /// and we want to avoid the overhead of checking the memory usage after the fact.
-    pub(super) fn insert_reserved(&self, entry_id: CacheEntryID, reservation: MemoryReservation) {
-        self.cached_data.insert(&entry_id, reservation.into_inner());
     }
 
     fn insert_inner(
@@ -225,10 +176,10 @@ impl CacheStore {
                     return Some(not_inserted);
                 };
 
-                if let CachedBatch::ArrowMemory(array) = to_transcode_batch {
+                if let CachedBatch::MemoryArrow(array) = to_transcode_batch {
                     let liquid_array = transcode_liquid_inner(&array, compressor_states.as_ref())
                         .expect("Failed to transcode to liquid array");
-                    let liquid_array = CachedBatch::LiquidMemory(liquid_array);
+                    let liquid_array = CachedBatch::MemoryLiquid(liquid_array);
                     self.insert_inner(to_transcode, liquid_array)
                         .expect("Failed to insert the transcoded batch");
                 }
@@ -241,48 +192,80 @@ impl CacheStore {
                     return Some(not_inserted);
                 };
                 let liquid_array = match to_evict_batch {
-                    CachedBatch::ArrowMemory(array) => {
+                    CachedBatch::MemoryArrow(array) => {
                         transcode_liquid_inner(&array, compressor_states.as_ref())
                             .expect("Failed to transcode to liquid array")
                     }
-                    CachedBatch::LiquidMemory(liquid_array) => liquid_array,
-                    CachedBatch::OnDiskLiquid => {
+                    CachedBatch::MemoryLiquid(liquid_array) => liquid_array,
+                    CachedBatch::DiskLiquid => {
+                        // do nothing, already on disk
+                        return Some(not_inserted);
+                    }
+                    CachedBatch::DiskArrow => {
                         // do nothing, already on disk
                         return Some(not_inserted);
                     }
                 };
-                self.write_to_disk(&to_evict, &liquid_array);
-                self.insert_inner(to_evict, CachedBatch::OnDiskLiquid)
+                self.write_liquid_to_disk(&to_evict, &liquid_array);
+                self.insert_inner(to_evict, CachedBatch::DiskLiquid)
                     .expect("failed to insert on disk liquid");
                 Some(not_inserted)
             }
             CacheAdvice::TranscodeToDisk(to_transcode) => {
                 let compressor_states = self.compressor_states.get_compressor(&to_transcode);
                 let liquid_array = match not_inserted {
-                    CachedBatch::ArrowMemory(array) => {
+                    CachedBatch::MemoryArrow(array) => {
                         transcode_liquid_inner(&array, compressor_states.as_ref())
                             .expect("Failed to transcode to liquid array")
                     }
-                    CachedBatch::LiquidMemory(liquid_array) => liquid_array,
-                    CachedBatch::OnDiskLiquid => {
+                    CachedBatch::MemoryLiquid(liquid_array) => liquid_array,
+                    CachedBatch::DiskLiquid => {
+                        return None;
+                    }
+                    CachedBatch::DiskArrow => {
                         return None;
                     }
                 };
-                self.write_to_disk(&to_transcode, &liquid_array);
-                self.insert_inner(to_transcode, CachedBatch::OnDiskLiquid)
+                self.write_liquid_to_disk(&to_transcode, &liquid_array);
+                self.insert_inner(to_transcode, CachedBatch::DiskLiquid)
                     .expect("failed to insert on disk liquid");
+                None
+            }
+            CacheAdvice::ToDisk(to_disk) => {
+                match not_inserted {
+                    CachedBatch::MemoryArrow(array) => {
+                        self.write_arrow_to_disk(&to_disk, &array);
+                        self.insert_inner(to_disk, CachedBatch::DiskArrow)
+                            .expect("failed to insert on disk arrow");
+                    }
+                    CachedBatch::MemoryLiquid(liquid_array) => {
+                        self.write_liquid_to_disk(&to_disk, &liquid_array);
+                        self.insert_inner(to_disk, CachedBatch::DiskLiquid)
+                            .expect("failed to insert on disk liquid");
+                    }
+                    CachedBatch::DiskLiquid | CachedBatch::DiskArrow => {
+                        // Already on disk, nothing to do
+                        return None;
+                    }
+                }
                 None
             }
             CacheAdvice::Discard => None,
         }
     }
 
-    fn write_to_disk(&self, entry_id: &CacheEntryID, liquid_array: &LiquidArrayRef) {
-        let bytes = liquid_array.to_bytes();
-        let file_path = entry_id.on_disk_path(self.config.cache_root_dir());
-        let mut file = File::create(file_path).unwrap();
-        file.write_all(&bytes).unwrap();
-        self.budget.add_used_disk_bytes(bytes.len());
+    fn write_liquid_to_disk(&self, entry_id: &CacheEntryID, liquid_array: &LiquidArrayRef) {
+        let disk_usage = entry_id
+            .on_disk_liquid_path(self.config.cache_root_dir(), liquid_array)
+            .expect("failed to write liquid to disk");
+        self.budget.add_used_disk_bytes(disk_usage);
+    }
+
+    fn write_arrow_to_disk(&self, entry_id: &CacheEntryID, array: &arrow::array::ArrayRef) {
+        let disk_usage = entry_id
+            .write_arrow_to_disk(self.config.cache_root_dir(), array)
+            .expect("failed to write arrow to disk");
+        self.budget.add_used_disk_bytes(disk_usage);
     }
 
     pub(super) fn insert(&self, entry_id: CacheEntryID, mut batch_to_cache: CachedBatch) {
@@ -388,7 +371,7 @@ mod tests {
 
             // Get should return the cached value
             match store.get(&entry_id1) {
-                Some(CachedBatch::ArrowMemory(arr)) => assert_eq!(arr.len(), 100),
+                Some(CachedBatch::MemoryArrow(arr)) => assert_eq!(arr.len(), 100),
                 _ => panic!("Expected ArrowMemory batch"),
             }
         }
@@ -423,6 +406,7 @@ mod tests {
         Evict,
         Transcode,
         TranscodeToDisk,
+        ToDisk,
     }
 
     impl TestPolicy {
@@ -448,6 +432,7 @@ mod tests {
                     CacheAdvice::Transcode(id_to_use)
                 }
                 AdviceType::TranscodeToDisk => CacheAdvice::TranscodeToDisk(*entry_id),
+                AdviceType::ToDisk => CacheAdvice::ToDisk(*entry_id),
             }
         }
     }
@@ -471,7 +456,7 @@ mod tests {
         assert_eq!(store.budget.memory_usage_bytes(), size1);
         let retrieved1 = store.get(&entry_id1).unwrap();
         match retrieved1 {
-            CachedBatch::ArrowMemory(arr) => assert_eq!(arr.len(), 100),
+            CachedBatch::MemoryArrow(arr) => assert_eq!(arr.len(), 100),
             _ => panic!("Expected ArrowMemory"),
         }
 
@@ -509,13 +494,13 @@ mod tests {
 
             store.insert(entry_id1, create_test_array(800));
             match store.get(&entry_id1).unwrap() {
-                CachedBatch::ArrowMemory(_) => {}
+                CachedBatch::MemoryArrow(_) => {}
                 other => panic!("Expected ArrowMemory, got {:?}", other),
             }
 
             store.insert(entry_id2, create_test_array(800));
             match store.get(&entry_id1).unwrap() {
-                CachedBatch::OnDiskLiquid => {}
+                CachedBatch::DiskLiquid => {}
                 other => panic!("Expected OnDiskLiquid after eviction, got {:?}", other),
             }
         }
@@ -527,13 +512,13 @@ mod tests {
 
             store.insert(entry_id1, create_test_array(800));
             match store.get(&entry_id1).unwrap() {
-                CachedBatch::ArrowMemory(_) => {}
+                CachedBatch::MemoryArrow(_) => {}
                 other => panic!("Expected ArrowMemory, got {:?}", other),
             }
 
             store.insert(entry_id2, create_test_array(800));
             match store.get(&entry_id1).unwrap() {
-                CachedBatch::LiquidMemory(_) => {}
+                CachedBatch::MemoryLiquid(_) => {}
                 other => panic!("Expected LiquidMemory after transcoding, got {:?}", other),
             }
         }
@@ -549,8 +534,26 @@ mod tests {
             store.insert(entry_id1, create_test_array(800));
             store.insert(entry_id3, create_test_array(800));
             match store.get(&entry_id3).unwrap() {
-                CachedBatch::OnDiskLiquid => {}
+                CachedBatch::DiskLiquid => {}
                 other => panic!("Expected OnDiskLiquid, got {:?}", other),
+            }
+        }
+
+        // 4. Test TO_DISK advice - preserve format as-is
+        {
+            let advisor = TestPolicy::new(AdviceType::ToDisk, None);
+            let store = create_cache_store(8000, Box::new(advisor)); // Small budget to force disk storage
+
+            let on_disk_arrow_path = entry_id1.on_disk_arrow_path(&store.config.cache_root_dir());
+            std::fs::create_dir_all(on_disk_arrow_path.parent().unwrap()).unwrap();
+
+            // Insert arrow data - should be written as DiskArrow (preserving format)
+            store.insert(entry_id1, create_test_array(800));
+            store.insert(entry_id2, create_test_array(800)); // This should trigger ToDisk advice
+
+            match store.get(&entry_id2).unwrap() {
+                CachedBatch::DiskArrow => {}
+                other => panic!("Expected DiskArrow after ToDisk advice, got {:?}", other),
             }
         }
     }

--- a/src/liquid_parquet/src/cache/utils.rs
+++ b/src/liquid_parquet/src/cache/utils.rs
@@ -423,7 +423,7 @@ mod tests {
             .join("file_1")
             .join("rg_2")
             .join("col_3")
-            .join("batch_4.bin");
+            .join("batch_4.liquid");
         assert_eq!(entry_id.on_disk_path(cache_root), expected_path);
     }
 

--- a/src/liquid_parquet/src/cache/utils.rs
+++ b/src/liquid_parquet/src/cache/utils.rs
@@ -201,7 +201,7 @@ impl CacheEntryID {
     ) -> Result<usize, std::io::Error> {
         let path = self.on_disk_path(cache_root_dir);
         let bytes = array.to_bytes();
-        let mut file = File::create(path)?;
+        let mut file = File::create(&path)?;
         file.write_all(&bytes)?;
         Ok(bytes.len())
     }

--- a/src/liquid_parquet/src/cache/utils.rs
+++ b/src/liquid_parquet/src/cache/utils.rs
@@ -182,7 +182,7 @@ impl CacheEntryID {
             .join(format!("file_{}", self.file_id_inner()))
             .join(format!("rg_{}", self.row_group_id_inner()))
             .join(format!("col_{}", self.column_id_inner()))
-            .join(format!("batch_{batch_id}.bin"))
+            .join(format!("batch_{batch_id}.liquid"))
     }
 
     pub(super) fn on_disk_arrow_path(&self, cache_root_dir: &Path) -> PathBuf {
@@ -194,17 +194,12 @@ impl CacheEntryID {
             .join(format!("batch_{batch_id}.arrow"))
     }
 
-    pub(super) fn on_disk_liquid_path(
+    pub(super) fn write_liquid_to_disk(
         &self,
         cache_root_dir: &Path,
         array: &LiquidArrayRef,
     ) -> Result<usize, std::io::Error> {
-        let batch_id = self.batch_id_inner();
-        let path = cache_root_dir
-            .join(format!("file_{}", self.file_id_inner()))
-            .join(format!("rg_{}", self.row_group_id_inner()))
-            .join(format!("col_{}", self.column_id_inner()))
-            .join(format!("batch_{batch_id}.liquid"));
+        let path = self.on_disk_path(cache_root_dir);
         let bytes = array.to_bytes();
         let mut file = File::create(path)?;
         file.write_all(&bytes)?;

--- a/src/liquid_parquet/src/inprocess.rs
+++ b/src/liquid_parquet/src/inprocess.rs
@@ -46,7 +46,7 @@ use crate::{LiquidCache, LiquidCacheRef, LiquidParquetSource};
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let temp_dir = TempDir::new().unwrap();
 ///
-///     let ctx = LiquidCacheInProcessBuilder::new()
+///     let (ctx, _) = LiquidCacheInProcessBuilder::new()
 ///         .with_max_cache_bytes(1024 * 1024 * 1024) // 1GB
 ///         .with_cache_dir(temp_dir.path().to_path_buf())
 ///         .with_cache_mode(LiquidCacheMode::Liquid { transcode_in_background: false })
@@ -140,6 +140,7 @@ impl LiquidCacheInProcessBuilder {
             CacheEvictionStrategy::Discard => Box::new(crate::policies::DiscardPolicy),
             CacheEvictionStrategy::Lru => Box::new(crate::policies::LruPolicy::new()),
             CacheEvictionStrategy::Filo => Box::new(crate::policies::FiloPolicy::new()),
+            CacheEvictionStrategy::ToDisk => Box::new(crate::policies::ToDiskPolicy::new()),
         };
         let cache = LiquidCache::new(
             self.batch_size,

--- a/src/liquid_parquet/src/liquid_array/ipc.rs
+++ b/src/liquid_parquet/src/liquid_array/ipc.rs
@@ -4,8 +4,8 @@ use std::{any::TypeId, mem::size_of};
 use arrow::array::ArrowPrimitiveType;
 use arrow::array::types::UInt16Type;
 use arrow::datatypes::{
-    Date32Type, Date64Type, Float32Type, Float64Type, Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type, UInt32Type,
-    UInt64Type,
+    Date32Type, Date64Type, Float32Type, Float64Type, Int8Type, Int16Type, Int32Type, Int64Type,
+    UInt8Type, UInt32Type, UInt64Type,
 };
 use bytes::Bytes;
 use fsst::Compressor;
@@ -120,7 +120,7 @@ pub fn read_from_bytes(bytes: Bytes, context: &LiquidIPCContext) -> LiquidArrayR
             7 => Arc::new(LiquidPrimitiveArray::<UInt64Type>::from_bytes(bytes)),
             10 => Arc::new(LiquidPrimitiveArray::<Date32Type>::from_bytes(bytes)),
             11 => Arc::new(LiquidPrimitiveArray::<Date64Type>::from_bytes(bytes)),
-            v => panic!("Unsupported integer physical type: {}", v),
+            v => panic!("Unsupported integer physical type: {v}"),
         },
         LiquidDataType::ByteArray => {
             let compressor = context.compressor.as_ref().expect("Expected a compressor");
@@ -129,7 +129,7 @@ pub fn read_from_bytes(bytes: Bytes, context: &LiquidIPCContext) -> LiquidArrayR
         LiquidDataType::Float => match header.physical_type_id {
             8 => Arc::new(LiquidFloatArray::<Float32Type>::from_bytes(bytes)),
             9 => Arc::new(LiquidFloatArray::<Float64Type>::from_bytes(bytes)),
-            v => panic!("Unsupported float physical type: {}", v),
+            v => panic!("Unsupported float physical type: {v}"),
         },
         LiquidDataType::FixedLenByteArray => {
             let compressor = context.compressor.as_ref().expect("Expected a compressor");
@@ -966,15 +966,18 @@ mod tests {
     fn test_date_types_ipc_roundtrip() {
         // Test Date32Type
         let date32_array = PrimitiveArray::<Date32Type>::from(vec![Some(18628), None, Some(0)]);
-        let liquid_array = LiquidPrimitiveArray::<Date32Type>::from_arrow_array(date32_array.clone());
+        let liquid_array =
+            LiquidPrimitiveArray::<Date32Type>::from_arrow_array(date32_array.clone());
         let bytes = Bytes::from(liquid_array.to_bytes());
         let context = LiquidIPCContext::new(None);
         let deserialized = read_from_bytes(bytes, &context);
         assert_eq!(deserialized.to_arrow_array().as_ref(), &date32_array);
 
         // Test Date64Type
-        let date64_array = PrimitiveArray::<Date64Type>::from(vec![Some(1609459200000), None, Some(0)]);
-        let liquid_array = LiquidPrimitiveArray::<Date64Type>::from_arrow_array(date64_array.clone());
+        let date64_array =
+            PrimitiveArray::<Date64Type>::from(vec![Some(1609459200000), None, Some(0)]);
+        let liquid_array =
+            LiquidPrimitiveArray::<Date64Type>::from_arrow_array(date64_array.clone());
         let bytes = Bytes::from(liquid_array.to_bytes());
         let context = LiquidIPCContext::new(None);
         let deserialized = read_from_bytes(bytes, &context);

--- a/src/server/src/service.rs
+++ b/src/server/src/service.rs
@@ -13,7 +13,9 @@ use datafusion::{
 use liquid_cache_common::{
     CacheEvictionStrategy, CacheMode, coerce_to_liquid_cache_types, rpc::ExecutionMetricsResponse,
 };
-use liquid_cache_parquet::policies::{CachePolicy, DiscardPolicy, FiloPolicy, LruPolicy};
+use liquid_cache_parquet::policies::{
+    CachePolicy, DiscardPolicy, FiloPolicy, LruPolicy, ToDiskPolicy,
+};
 use liquid_cache_parquet::{LiquidCache, LiquidCacheRef, LiquidParquetSource};
 use log::{debug, info};
 use object_store::ObjectStore;
@@ -62,6 +64,7 @@ impl LiquidCacheServiceInner {
             CacheEvictionStrategy::Lru => Box::new(LruPolicy::new()),
             CacheEvictionStrategy::Discard => Box::new(DiscardPolicy),
             CacheEvictionStrategy::Filo => Box::new(FiloPolicy::new()),
+            CacheEvictionStrategy::ToDisk => Box::new(ToDiskPolicy::new()),
         };
 
         let liquid_cache = match cache_mode {


### PR DESCRIPTION
Now we can directly write arrow without first transcoding to liquid