### PR TITLE
Update cache mode docstring

### DIFF
--- a/src/liquid_parquet/src/inprocess.rs
+++ b/src/liquid_parquet/src/inprocess.rs
@@ -53,7 +53,7 @@ pub struct LiquidCacheInProcessBuilder {
     max_cache_bytes: usize,
     /// Directory for disk cache
     cache_dir: PathBuf,
-    /// Cache mode (InMemoryArrow or InMemoryLiquid)
+    /// Cache mode (`LiquidCacheMode::Arrow` or `LiquidCacheMode::Liquid`)
     cache_mode: LiquidCacheMode,
     /// Cache eviction strategy
     cache_strategy: CacheEvictionStrategy,


### PR DESCRIPTION
## Summary
- update documentation for cache mode enum in inprocess builder

## Testing
- `cargo fmt --all`
- `cargo test -p liquid-cache-parquet`

------
https://chatgpt.com/codex/tasks/task_e_684efaf2bd108332b5de55ff8316ae91