### PR TITLE
Better inprocess benchmark

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -112,5 +112,28 @@
 			],
 			"cwd": "${workspaceFolder}"
 		},
+		{
+			"type": "lldb",
+			"request": "launch",
+			"name": "inprocess",
+			"cargo": {
+				"args": [
+					"build",
+					"--bin=in_process",
+				],
+				"filter": {
+					"name": "in_process",
+					"kind": "bin"
+				}
+			},
+			"env": {
+				"RUST_LOG": "info"
+			},
+			"args": [
+				"--manifest",
+				"benchmark/data/openobserve.json",
+			],
+			"cwd": "${workspaceFolder}"
+		},
 	]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,8 +769,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2867,10 +2869,17 @@ dependencies = [
  "arrow",
  "arrow-flight",
  "arrow-schema",
+ "async-trait",
  "bytes",
+ "chrono",
+ "futures",
+ "object_store",
+ "parking_lot",
  "prost",
  "serde",
  "tempfile",
+ "thiserror 2.0.12",
+ "tokio",
  "url",
 ]
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -66,3 +66,7 @@ path = "bench_server.rs"
 [[bin]]
 name = "cache_behavior"
 path = "cache_behavior.rs"
+
+[[bin]]
+name = "in_process"
+path = "in_process.rs"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -76,6 +76,37 @@ cargo run --release --bin bench_server -- --cache-mode liquid_eager_transcode
 env RUST_LOG=info,clickbench_client=debug RUSTFLAGS='-C target-cpu=native' cargo run --release --bin tpch_client -- --query-dir benchmark/tpch/queries/ --data-dir benchmark/tpch/data/sf0.1  --iteration 3 --answer-dir benchmark/tpch/answers/sf0.1
 ```
 
+## In process mode
+The benchmark uses a JSON manifest file to describe the data tables and queries to run.
+
+### JSON Format
+
+```json
+{
+  "name": "My Benchmark Suite",
+  "description": "Description of what this benchmark tests",
+  "tables": {
+    "table1": "data/table1.parquet",
+    "table2": "data/table2.parquet"
+  },
+  "queries": [
+    "queries/aggregation.sql",
+    "SELECT COUNT(*) FROM table1 WHERE col > 100",
+    "queries/complex_join.sql",
+    "SELECT t1.id, t2.name FROM table1 t1 JOIN table2 t2 ON t1.id = t2.id LIMIT 10"
+  ],
+  "object_stores": [
+    {
+      "url": "s3://my-bucket",
+      "options": {
+        "aws_access_key_id": "my-access-key",
+        "aws_secret_access_key": "my-secret-key",
+        "aws_region": "us-west-2"
+      }
+    }
+  ]
+}
+```
 
 
 ## Profile

--- a/benchmark/in_process.rs
+++ b/benchmark/in_process.rs
@@ -1,76 +1,14 @@
 use anyhow::Result;
 use clap::Parser;
-use datafusion::execution::object_store::ObjectStoreUrl;
-use datafusion::prelude::SessionConfig;
-use datafusion::prelude::SessionContext;
 use liquid_cache_benchmarks::{
-    BenchmarkResult, IterationResult, Query, QueryResult, run_query, setup_observability,
+    setup_observability, BenchmarkManifest, InProcessBenchmarkMode, InProcessBenchmarkRunner,
 };
-use liquid_cache_common::{CacheEvictionStrategy, LiquidCacheMode};
-use liquid_cache_parquet::{LiquidCacheInProcessBuilder, LiquidCacheRef};
-use log::info;
 use mimalloc::MiMalloc;
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    fs::{File, create_dir_all},
-    path::PathBuf,
-    sync::Arc,
-    time::Instant,
-};
-use sysinfo::Disks;
+use serde::Serialize;
+use std::path::PathBuf;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
-
-#[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Serialize)]
-enum BenchmarkMode {
-    Parquet,
-    Arrow,
-    #[default]
-    Liquid,
-    LiquidEagerTranscode,
-}
-
-impl std::str::FromStr for BenchmarkMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "parquet" => BenchmarkMode::Parquet,
-            "arrow" => BenchmarkMode::Arrow,
-            "liquid" => BenchmarkMode::Liquid,
-            "liquid-eager-transcode" => BenchmarkMode::LiquidEagerTranscode,
-            _ => {
-                return Err(format!(
-                    "Invalid benchmark mode: {s}, must be one of: parquet, arrow, liquid, liquid-eager-transcode"
-                ));
-            }
-        })
-    }
-}
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct ObjectStoreConfig {
-    /// Object store URL (e.g., "s3://bucket-name", "gs://bucket-name", "http://localhost:9000")
-    pub url: String,
-    /// Optional configuration options for the object store
-    pub options: Option<HashMap<String, String>>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct BenchmarkManifest {
-    /// Name of the benchmark suite
-    pub name: String,
-    /// Description of the benchmark
-    pub description: Option<String>,
-    /// Data tables configuration: table name -> parquet file path
-    pub tables: HashMap<String, String>,
-    /// Array of SQL queries - each element can be a file path or inline SQL
-    pub queries: Vec<String>,
-    /// Optional object store configurations
-    pub object_stores: Option<Vec<ObjectStoreConfig>>,
-}
 
 #[derive(Parser, Serialize, Clone)]
 #[command(name = "In-Process Benchmark")]
@@ -81,7 +19,7 @@ struct InProcessBenchmark {
 
     /// Benchmark mode to use
     #[arg(long = "bench-mode", default_value = "liquid-eager-transcode")]
-    pub bench_mode: BenchmarkMode,
+    pub bench_mode: InProcessBenchmarkMode,
 
     /// Number of times to run each query
     #[arg(long, default_value = "3")]
@@ -112,283 +50,22 @@ struct InProcessBenchmark {
     pub query_index: Option<usize>,
 }
 
-fn write_flamegraph(
-    profiler: &pprof::ProfilerGuard,
-    flamegraph_dir: &PathBuf,
-    query_index: usize,
-    iteration: u32,
-) -> Result<()> {
-    let report = profiler.report().build()?;
-    let mut svg_data = Vec::new();
-    report.flamegraph(&mut svg_data)?;
-    create_dir_all(flamegraph_dir)?;
-
-    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
-    let secs = now.as_secs();
-    let hour = (secs / 3600) % 24;
-    let minute = (secs / 60) % 60;
-    let second = secs % 60;
-
-    let filename = format!(
-        "{:02}h{:02}m{:02}s_q{}_i{}.svg",
-        hour, minute, second, query_index, iteration
-    );
-    let filepath = flamegraph_dir.join(filename);
-    std::fs::write(&filepath, svg_data)?;
-    info!("Flamegraph written to: {}", filepath.display());
-
-    Ok(())
-}
-
 impl InProcessBenchmark {
-    fn load_manifest(&self) -> Result<BenchmarkManifest> {
-        let manifest_content = std::fs::read_to_string(&self.manifest)?;
-        let manifest: BenchmarkManifest = serde_json::from_str(&manifest_content)?;
-        Ok(manifest)
-    }
+    pub async fn run(self) -> Result<()> {
+        let manifest = BenchmarkManifest::load_from_file(&self.manifest)?;
+        let output = self.output.clone();
+        
+        let runner = InProcessBenchmarkRunner::new()
+            .with_bench_mode(self.bench_mode)
+            .with_iteration(self.iteration)
+            .with_reset_cache(self.reset_cache)
+            .with_partitions(self.partitions)
+            .with_max_cache_mb(self.max_cache_mb)
+            .with_flamegraph_dir(self.flamegraph_dir.clone())
+            .with_query_filter(self.query_index);
 
-    /// Determine if a string is a file path or inline SQL
-    /// If it ends with .sql or contains path separators, treat as file path
-    /// Otherwise, treat as inline SQL
-    fn is_file_path(query_str: &str) -> bool {
-        query_str.ends_with(".sql")
-            || query_str.contains('/')
-            || query_str.contains('\\')
-            || (!query_str.contains(' ') && !query_str.contains('\n'))
-    }
-
-    async fn setup_context(
-        &self,
-        manifest: &BenchmarkManifest,
-    ) -> Result<(Arc<SessionContext>, Option<LiquidCacheRef>)> {
-        let mut session_config = SessionConfig::from_env()?;
-
-        session_config
-            .options_mut()
-            .execution
-            .parquet
-            .pushdown_filters = true;
-        if let Some(partitions) = self.partitions {
-            session_config.options_mut().execution.target_partitions = partitions;
-        }
-        session_config.options_mut().execution.batch_size = 8192 * 2;
-
-        let cache_size = self
-            .max_cache_mb
-            .map(|size| size * 1024 * 1024)
-            .unwrap_or(usize::MAX);
-
-        let cache_dir = std::env::current_dir()?.join("benchmark/data/cache");
-        if cache_dir.exists() {
-            std::fs::remove_dir_all(&cache_dir)?;
-        }
-        std::fs::create_dir_all(&cache_dir)?;
-
-        let (ctx, cache): (SessionContext, Option<LiquidCacheRef>) = match self.bench_mode {
-            BenchmarkMode::Parquet => (SessionContext::new_with_config(session_config), None),
-            BenchmarkMode::Arrow => {
-                let v = LiquidCacheInProcessBuilder::new()
-                    .with_max_cache_bytes(cache_size)
-                    .with_cache_mode(LiquidCacheMode::Arrow)
-                    .with_cache_dir(cache_dir)
-                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
-                    .build(session_config)?;
-                (v.0, Some(v.1))
-            }
-            BenchmarkMode::Liquid => {
-                let v = LiquidCacheInProcessBuilder::new()
-                    .with_max_cache_bytes(cache_size)
-                    .with_cache_mode(LiquidCacheMode::Liquid {
-                        transcode_in_background: true,
-                    })
-                    .with_cache_dir(cache_dir)
-                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
-                    .build(session_config)?;
-                (v.0, Some(v.1))
-            }
-            BenchmarkMode::LiquidEagerTranscode => {
-                let v = LiquidCacheInProcessBuilder::new()
-                    .with_max_cache_bytes(cache_size)
-                    .with_cache_mode(LiquidCacheMode::Liquid {
-                        transcode_in_background: false,
-                    })
-                    .with_cache_dir(cache_dir)
-                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
-                    .build(session_config)?;
-                (v.0, Some(v.1))
-            }
-        };
-
-        // Register object stores if configured
-        if let Some(object_stores) = &manifest.object_stores {
-            for store_config in object_stores {
-                let url = ObjectStoreUrl::parse(&store_config.url)?;
-                let options = store_config.options.clone().unwrap_or_default();
-
-                let (object_store, _) = object_store::parse_url_opts(url.as_ref(), options)?;
-                ctx.register_object_store(url.as_ref(), Arc::new(object_store));
-                info!("Registered object store: {}", store_config.url);
-            }
-        }
-
-        // Register tables from manifest
-        for (table_name, table_path_str) in &manifest.tables {
-            ctx.register_parquet(table_name, table_path_str, Default::default())
-                .await?;
-            info!("Registered table '{}' from {}", table_name, table_path_str);
-        }
-
-        Ok((Arc::new(ctx), cache))
-    }
-
-    async fn load_queries(&self, manifest: &BenchmarkManifest) -> Result<Vec<Query>> {
-        let mut queries = Vec::new();
-
-        for (index, query_str) in manifest.queries.iter().enumerate() {
-            let sql = if Self::is_file_path(query_str) {
-                // Treat as file path
-                let sql = std::fs::read_to_string(query_str)?;
-                info!("Loaded query {} from file: {}", index, query_str);
-                sql
-            } else {
-                // Treat as inline SQL
-                info!("Loaded query {} from inline SQL", index);
-                query_str.clone()
-            };
-
-            queries.push(Query {
-                id: index as u32,
-                sql,
-            });
-        }
-
-        Ok(queries)
-    }
-
-    async fn run_single_iteration(
-        &self,
-        ctx: &Arc<SessionContext>,
-        query: &Query,
-        bench_start_time: Instant,
-        cache: Option<LiquidCacheRef>,
-        iteration: u32,
-    ) -> Result<IterationResult> {
-        info!(
-            "Running query {} iteration {}: \n{}",
-            query.id, iteration, query.sql
-        );
-
-        // Start flamegraph profiling if enabled
-        let profiler_guard = if self.flamegraph_dir.is_some() {
-            Some(
-                pprof::ProfilerGuardBuilder::default()
-                    .frequency(500)
-                    .blocklist(&["libpthread.so.0", "libm.so.6", "libgcc_s.so.1"])
-                    .build()?,
-            )
-        } else {
-            None
-        };
-
-        // Capture disk I/O metrics before query execution
-        let mut disk_info = Disks::new_with_refreshed_list();
-
-        let now = Instant::now();
-        let starting_timestamp = bench_start_time.elapsed();
-
-        let (_results, _execution_plan, _) = run_query(ctx, &query.sql).await?;
-        let elapsed = now.elapsed();
-
-        disk_info.refresh(true);
-        let disk_read: u64 = disk_info.iter().map(|disk| disk.usage().read_bytes).sum();
-        let disk_written: u64 = disk_info
-            .iter()
-            .map(|disk| disk.usage().written_bytes)
-            .sum();
-
-        // Stop flamegraph profiling and write to file if enabled
-        if let Some(profiler) = profiler_guard
-            && let Some(flamegraph_dir) = &self.flamegraph_dir
-        {
-            write_flamegraph(&profiler, flamegraph_dir, query.id as usize, iteration)?;
-        }
-
-        let cache_memory_usage = if let Some(cache) = cache {
-            cache.memory_usage_bytes()
-        } else {
-            0
-        };
-
-        let result = IterationResult {
-            network_traffic: 0,
-            time_millis: elapsed.as_millis() as u64,
-            cache_cpu_time: 0, // Not easily available for in-process
-            cache_memory_usage: cache_memory_usage as u64,
-            liquid_cache_usage: cache_memory_usage as u64,
-            disk_bytes_read: disk_read,
-            disk_bytes_written: disk_written,
-            starting_timestamp,
-        };
-
-        info!("\n{result}");
-        Ok(result)
-    }
-
-    pub async fn run(self) -> Result<BenchmarkResult<InProcessBenchmark>> {
-        let manifest = self.load_manifest()?;
-        info!("Loaded benchmark manifest: {}", manifest.name);
-
-        let (ctx, cache) = self.setup_context(&manifest).await?;
-        let queries = self.load_queries(&manifest).await?;
-
-        // Filter queries if specific query index is requested
-        let query_indices: Vec<usize> = if let Some(query_index) = self.query_index {
-            if query_index >= queries.len() {
-                return Err(anyhow::anyhow!(
-                    "Query index {} out of range (max: {})",
-                    query_index,
-                    queries.len() - 1
-                ));
-            }
-            vec![query_index]
-        } else {
-            (0..queries.len()).collect()
-        };
-
-        let mut benchmark_result = BenchmarkResult {
-            args: self.clone(),
-            results: Vec::new(),
-        };
-
-        let bench_start_time = Instant::now();
-
-        for query_index in query_indices {
-            let query = &queries[query_index];
-            let mut query_result = QueryResult::new(query.id, query.sql.clone());
-
-            for it in 0..self.iteration {
-                let iteration_result = self
-                    .run_single_iteration(&ctx, query, bench_start_time, cache.clone(), it + 1)
-                    .await?;
-
-                query_result.add(iteration_result);
-
-                if self.reset_cache
-                    && let Some(cache) = &cache
-                {
-                    cache.reset();
-                }
-            }
-
-            benchmark_result.results.push(query_result);
-        }
-
-        if let Some(output_path) = &self.output {
-            let output_file = File::create(output_path)?;
-            serde_json::to_writer_pretty(output_file, &benchmark_result)?;
-        }
-
-        Ok(benchmark_result)
+        runner.run(manifest, self, output).await?;
+        Ok(())
     }
 }
 

--- a/benchmark/in_process.rs
+++ b/benchmark/in_process.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use liquid_cache_benchmarks::{
-    setup_observability, BenchmarkManifest, InProcessBenchmarkMode, InProcessBenchmarkRunner,
+    BenchmarkManifest, InProcessBenchmarkMode, InProcessBenchmarkRunner, setup_observability,
 };
 use mimalloc::MiMalloc;
 use serde::Serialize;
@@ -54,7 +54,7 @@ impl InProcessBenchmark {
     pub async fn run(self) -> Result<()> {
         let manifest = BenchmarkManifest::load_from_file(&self.manifest)?;
         let output = self.output.clone();
-        
+
         let runner = InProcessBenchmarkRunner::new()
             .with_bench_mode(self.bench_mode)
             .with_iteration(self.iteration)

--- a/benchmark/in_process.rs
+++ b/benchmark/in_process.rs
@@ -1,0 +1,401 @@
+use anyhow::Result;
+use clap::Parser;
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::prelude::SessionConfig;
+use datafusion::prelude::SessionContext;
+use liquid_cache_benchmarks::{
+    BenchmarkResult, IterationResult, Query, QueryResult, run_query, setup_observability,
+};
+use liquid_cache_common::{CacheEvictionStrategy, LiquidCacheMode};
+use liquid_cache_parquet::{LiquidCacheInProcessBuilder, LiquidCacheRef};
+use log::info;
+use mimalloc::MiMalloc;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fs::{File, create_dir_all},
+    path::PathBuf,
+    sync::Arc,
+    time::Instant,
+};
+use sysinfo::Disks;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+#[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Serialize)]
+enum BenchmarkMode {
+    Parquet,
+    Arrow,
+    #[default]
+    Liquid,
+    LiquidEagerTranscode,
+}
+
+impl std::str::FromStr for BenchmarkMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "parquet" => BenchmarkMode::Parquet,
+            "arrow" => BenchmarkMode::Arrow,
+            "liquid" => BenchmarkMode::Liquid,
+            "liquid-eager-transcode" => BenchmarkMode::LiquidEagerTranscode,
+            _ => {
+                return Err(format!(
+                    "Invalid benchmark mode: {s}, must be one of: parquet, arrow, liquid, liquid-eager-transcode"
+                ));
+            }
+        })
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ObjectStoreConfig {
+    /// Object store URL (e.g., "s3://bucket-name", "gs://bucket-name", "http://localhost:9000")
+    pub url: String,
+    /// Optional configuration options for the object store
+    pub options: Option<HashMap<String, String>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct BenchmarkManifest {
+    /// Name of the benchmark suite
+    pub name: String,
+    /// Description of the benchmark
+    pub description: Option<String>,
+    /// Data tables configuration: table name -> parquet file path
+    pub tables: HashMap<String, String>,
+    /// Array of SQL queries - each element can be a file path or inline SQL
+    pub queries: Vec<String>,
+    /// Optional object store configurations
+    pub object_stores: Option<Vec<ObjectStoreConfig>>,
+}
+
+#[derive(Parser, Serialize, Clone)]
+#[command(name = "In-Process Benchmark")]
+struct InProcessBenchmark {
+    /// Path to the benchmark manifest file (JSON)
+    #[arg(long = "manifest")]
+    pub manifest: PathBuf,
+
+    /// Benchmark mode to use
+    #[arg(long = "bench-mode", default_value = "liquid-eager-transcode")]
+    pub bench_mode: BenchmarkMode,
+
+    /// Number of times to run each query
+    #[arg(long, default_value = "3")]
+    pub iteration: u32,
+
+    /// Path to the output JSON file to save the benchmark results
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+
+    /// Reset the cache before running a new query
+    #[arg(long = "reset-cache", default_value = "false")]
+    pub reset_cache: bool,
+
+    /// Number of partitions to use
+    #[arg(long)]
+    pub partitions: Option<usize>,
+
+    /// Maximum cache size in bytes
+    #[arg(long = "max-cache-mb")]
+    pub max_cache_mb: Option<usize>,
+
+    /// Directory to write flamegraph SVG files to
+    #[arg(long = "flamegraph-dir")]
+    pub flamegraph_dir: Option<PathBuf>,
+
+    /// Query index to run (0-based), if not provided, all queries will be run
+    #[arg(long)]
+    pub query_index: Option<usize>,
+}
+
+fn write_flamegraph(
+    profiler: &pprof::ProfilerGuard,
+    flamegraph_dir: &PathBuf,
+    query_index: usize,
+    iteration: u32,
+) -> Result<()> {
+    let report = profiler.report().build()?;
+    let mut svg_data = Vec::new();
+    report.flamegraph(&mut svg_data)?;
+    create_dir_all(flamegraph_dir)?;
+
+    let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
+    let secs = now.as_secs();
+    let hour = (secs / 3600) % 24;
+    let minute = (secs / 60) % 60;
+    let second = secs % 60;
+
+    let filename = format!(
+        "{:02}h{:02}m{:02}s_q{}_i{}.svg",
+        hour, minute, second, query_index, iteration
+    );
+    let filepath = flamegraph_dir.join(filename);
+    std::fs::write(&filepath, svg_data)?;
+    info!("Flamegraph written to: {}", filepath.display());
+
+    Ok(())
+}
+
+impl InProcessBenchmark {
+    fn load_manifest(&self) -> Result<BenchmarkManifest> {
+        let manifest_content = std::fs::read_to_string(&self.manifest)?;
+        let manifest: BenchmarkManifest = serde_json::from_str(&manifest_content)?;
+        Ok(manifest)
+    }
+
+    /// Determine if a string is a file path or inline SQL
+    /// If it ends with .sql or contains path separators, treat as file path
+    /// Otherwise, treat as inline SQL
+    fn is_file_path(query_str: &str) -> bool {
+        query_str.ends_with(".sql")
+            || query_str.contains('/')
+            || query_str.contains('\\')
+            || (!query_str.contains(' ') && !query_str.contains('\n'))
+    }
+
+    async fn setup_context(
+        &self,
+        manifest: &BenchmarkManifest,
+    ) -> Result<(Arc<SessionContext>, Option<LiquidCacheRef>)> {
+        let mut session_config = SessionConfig::from_env()?;
+
+        session_config
+            .options_mut()
+            .execution
+            .parquet
+            .pushdown_filters = true;
+        if let Some(partitions) = self.partitions {
+            session_config.options_mut().execution.target_partitions = partitions;
+        }
+        session_config.options_mut().execution.batch_size = 8192 * 2;
+
+        let cache_size = self
+            .max_cache_mb
+            .map(|size| size * 1024 * 1024)
+            .unwrap_or(usize::MAX);
+
+        let cache_dir = std::env::current_dir()?.join("benchmark/data/cache");
+        if cache_dir.exists() {
+            std::fs::remove_dir_all(&cache_dir)?;
+        }
+        std::fs::create_dir_all(&cache_dir)?;
+
+        let (ctx, cache): (SessionContext, Option<LiquidCacheRef>) = match self.bench_mode {
+            BenchmarkMode::Parquet => (SessionContext::new_with_config(session_config), None),
+            BenchmarkMode::Arrow => {
+                let v = LiquidCacheInProcessBuilder::new()
+                    .with_max_cache_bytes(cache_size)
+                    .with_cache_mode(LiquidCacheMode::Arrow)
+                    .with_cache_dir(cache_dir)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
+                    .build(session_config)?;
+                (v.0, Some(v.1))
+            }
+            BenchmarkMode::Liquid => {
+                let v = LiquidCacheInProcessBuilder::new()
+                    .with_max_cache_bytes(cache_size)
+                    .with_cache_mode(LiquidCacheMode::Liquid {
+                        transcode_in_background: true,
+                    })
+                    .with_cache_dir(cache_dir)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
+                    .build(session_config)?;
+                (v.0, Some(v.1))
+            }
+            BenchmarkMode::LiquidEagerTranscode => {
+                let v = LiquidCacheInProcessBuilder::new()
+                    .with_max_cache_bytes(cache_size)
+                    .with_cache_mode(LiquidCacheMode::Liquid {
+                        transcode_in_background: false,
+                    })
+                    .with_cache_dir(cache_dir)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
+                    .build(session_config)?;
+                (v.0, Some(v.1))
+            }
+        };
+
+        // Register object stores if configured
+        if let Some(object_stores) = &manifest.object_stores {
+            for store_config in object_stores {
+                let url = ObjectStoreUrl::parse(&store_config.url)?;
+                let options = store_config.options.clone().unwrap_or_default();
+
+                let (object_store, _) = object_store::parse_url_opts(url.as_ref(), options)?;
+                ctx.register_object_store(url.as_ref(), Arc::new(object_store));
+                info!("Registered object store: {}", store_config.url);
+            }
+        }
+
+        // Register tables from manifest
+        for (table_name, table_path_str) in &manifest.tables {
+            ctx.register_parquet(table_name, table_path_str, Default::default())
+                .await?;
+            info!("Registered table '{}' from {}", table_name, table_path_str);
+        }
+
+        Ok((Arc::new(ctx), cache))
+    }
+
+    async fn load_queries(&self, manifest: &BenchmarkManifest) -> Result<Vec<Query>> {
+        let mut queries = Vec::new();
+
+        for (index, query_str) in manifest.queries.iter().enumerate() {
+            let sql = if Self::is_file_path(query_str) {
+                // Treat as file path
+                let sql = std::fs::read_to_string(query_str)?;
+                info!("Loaded query {} from file: {}", index, query_str);
+                sql
+            } else {
+                // Treat as inline SQL
+                info!("Loaded query {} from inline SQL", index);
+                query_str.clone()
+            };
+
+            queries.push(Query {
+                id: index as u32,
+                sql,
+            });
+        }
+
+        Ok(queries)
+    }
+
+    async fn run_single_iteration(
+        &self,
+        ctx: &Arc<SessionContext>,
+        query: &Query,
+        bench_start_time: Instant,
+        cache: Option<LiquidCacheRef>,
+        iteration: u32,
+    ) -> Result<IterationResult> {
+        info!(
+            "Running query {} iteration {}: \n{}",
+            query.id, iteration, query.sql
+        );
+
+        // Start flamegraph profiling if enabled
+        let profiler_guard = if self.flamegraph_dir.is_some() {
+            Some(
+                pprof::ProfilerGuardBuilder::default()
+                    .frequency(500)
+                    .blocklist(&["libpthread.so.0", "libm.so.6", "libgcc_s.so.1"])
+                    .build()?,
+            )
+        } else {
+            None
+        };
+
+        // Capture disk I/O metrics before query execution
+        let mut disk_info = Disks::new_with_refreshed_list();
+
+        let now = Instant::now();
+        let starting_timestamp = bench_start_time.elapsed();
+
+        let (_results, _execution_plan, _) = run_query(ctx, &query.sql).await?;
+        let elapsed = now.elapsed();
+
+        disk_info.refresh(true);
+        let disk_read: u64 = disk_info.iter().map(|disk| disk.usage().read_bytes).sum();
+        let disk_written: u64 = disk_info
+            .iter()
+            .map(|disk| disk.usage().written_bytes)
+            .sum();
+
+        // Stop flamegraph profiling and write to file if enabled
+        if let Some(profiler) = profiler_guard
+            && let Some(flamegraph_dir) = &self.flamegraph_dir
+        {
+            write_flamegraph(&profiler, flamegraph_dir, query.id as usize, iteration)?;
+        }
+
+        let cache_memory_usage = if let Some(cache) = cache {
+            cache.memory_usage_bytes()
+        } else {
+            0
+        };
+
+        let result = IterationResult {
+            network_traffic: 0,
+            time_millis: elapsed.as_millis() as u64,
+            cache_cpu_time: 0, // Not easily available for in-process
+            cache_memory_usage: cache_memory_usage as u64,
+            liquid_cache_usage: cache_memory_usage as u64,
+            disk_bytes_read: disk_read,
+            disk_bytes_written: disk_written,
+            starting_timestamp,
+        };
+
+        info!("\n{result}");
+        Ok(result)
+    }
+
+    pub async fn run(self) -> Result<BenchmarkResult<InProcessBenchmark>> {
+        let manifest = self.load_manifest()?;
+        info!("Loaded benchmark manifest: {}", manifest.name);
+
+        let (ctx, cache) = self.setup_context(&manifest).await?;
+        let queries = self.load_queries(&manifest).await?;
+
+        // Filter queries if specific query index is requested
+        let query_indices: Vec<usize> = if let Some(query_index) = self.query_index {
+            if query_index >= queries.len() {
+                return Err(anyhow::anyhow!(
+                    "Query index {} out of range (max: {})",
+                    query_index,
+                    queries.len() - 1
+                ));
+            }
+            vec![query_index]
+        } else {
+            (0..queries.len()).collect()
+        };
+
+        let mut benchmark_result = BenchmarkResult {
+            args: self.clone(),
+            results: Vec::new(),
+        };
+
+        let bench_start_time = Instant::now();
+
+        for query_index in query_indices {
+            let query = &queries[query_index];
+            let mut query_result = QueryResult::new(query.id, query.sql.clone());
+
+            for it in 0..self.iteration {
+                let iteration_result = self
+                    .run_single_iteration(&ctx, query, bench_start_time, cache.clone(), it + 1)
+                    .await?;
+
+                query_result.add(iteration_result);
+
+                if self.reset_cache
+                    && let Some(cache) = &cache
+                {
+                    cache.reset();
+                }
+            }
+
+            benchmark_result.results.push(query_result);
+        }
+
+        if let Some(output_path) = &self.output {
+            let output_file = File::create(output_path)?;
+            serde_json::to_writer_pretty(output_file, &benchmark_result)?;
+        }
+
+        Ok(benchmark_result)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    setup_observability("inprocess", opentelemetry::trace::SpanKind::Client, None);
+    let benchmark = InProcessBenchmark::parse();
+    benchmark.run().await?;
+    Ok(())
+}

--- a/benchmark/src/inprocess.rs
+++ b/benchmark/src/inprocess.rs
@@ -1,0 +1,514 @@
+use anyhow::Result;
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use liquid_cache_common::{CacheEvictionStrategy, LiquidCacheMode};
+use liquid_cache_parquet::{LiquidCacheInProcessBuilder, LiquidCacheRef};
+use log::info;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fs::{File, create_dir_all},
+    path::PathBuf,
+    sync::Arc,
+    time::Instant,
+};
+use sysinfo::Disks;
+
+use crate::{BenchmarkResult, IterationResult, Query, QueryResult, run_query};
+
+#[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Serialize)]
+pub enum InProcessBenchmarkMode {
+    Parquet,
+    Arrow,
+    #[default]
+    Liquid,
+    LiquidEagerTranscode,
+    Orc,
+}
+
+impl std::str::FromStr for InProcessBenchmarkMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "parquet" => InProcessBenchmarkMode::Parquet,
+            "arrow" => InProcessBenchmarkMode::Arrow,
+            "liquid" => InProcessBenchmarkMode::Liquid,
+            "liquid-eager-transcode" => InProcessBenchmarkMode::LiquidEagerTranscode,
+            "orc" => InProcessBenchmarkMode::Orc,
+            _ => {
+                return Err(format!(
+                    "Invalid in-process benchmark mode: {s}, must be one of: parquet, arrow, liquid, liquid-eager-transcode, orc"
+                ));
+            }
+        })
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ObjectStoreConfig {
+    /// Object store URL (e.g., "s3://bucket-name", "gs://bucket-name", "http://localhost:9000")
+    pub url: String,
+    /// Optional configuration options for the object store
+    pub options: Option<HashMap<String, String>>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct BenchmarkManifest {
+    /// Name of the benchmark suite
+    pub name: String,
+    /// Description of the benchmark
+    pub description: Option<String>,
+    /// Data tables configuration: table name -> parquet file path
+    pub tables: HashMap<String, String>,
+    /// Array of SQL queries - each element can be a file path or inline SQL
+    pub queries: Vec<String>,
+    /// Optional object store configurations
+    pub object_stores: Option<Vec<ObjectStoreConfig>>,
+    /// Special handling for queries (e.g., TPC-H Q15 has multiple statements)
+    pub special_query_handling: Option<HashMap<u32, String>>,
+}
+
+impl BenchmarkManifest {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            description: None,
+            tables: HashMap::new(),
+            queries: Vec::new(),
+            object_stores: None,
+            special_query_handling: None,
+        }
+    }
+
+    pub fn with_description(mut self, description: String) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn add_table<S: Into<String>>(mut self, name: S, path: S) -> Self {
+        self.tables.insert(name.into(), path.into());
+        self
+    }
+
+    pub fn add_query<S: Into<String>>(mut self, query: S) -> Self {
+        self.queries.push(query.into());
+        self
+    }
+
+    pub fn with_special_query_handling(mut self, handling: HashMap<u32, String>) -> Self {
+        self.special_query_handling = Some(handling);
+        self
+    }
+
+    pub fn save_to_file(&self, path: &PathBuf) -> Result<()> {
+        let file = File::create(path)?;
+        serde_json::to_writer_pretty(file, self)?;
+        Ok(())
+    }
+
+    pub fn load_from_file(path: &PathBuf) -> Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        let manifest: Self = serde_json::from_str(&content)?;
+        Ok(manifest)
+    }
+}
+
+pub struct InProcessBenchmarkRunner {
+    pub bench_mode: InProcessBenchmarkMode,
+    pub iteration: u32,
+    pub reset_cache: bool,
+    pub partitions: Option<usize>,
+    pub max_cache_mb: Option<usize>,
+    pub flamegraph_dir: Option<PathBuf>,
+    pub query_filter: Option<usize>,
+}
+
+impl InProcessBenchmarkRunner {
+    pub fn new() -> Self {
+        Self {
+            bench_mode: InProcessBenchmarkMode::default(),
+            iteration: 3,
+            reset_cache: false,
+            partitions: None,
+            max_cache_mb: None,
+            flamegraph_dir: None,
+            query_filter: None,
+        }
+    }
+
+    pub fn with_bench_mode(mut self, mode: InProcessBenchmarkMode) -> Self {
+        self.bench_mode = mode;
+        self
+    }
+
+    pub fn with_iteration(mut self, iteration: u32) -> Self {
+        self.iteration = iteration;
+        self
+    }
+
+    pub fn with_reset_cache(mut self, reset_cache: bool) -> Self {
+        self.reset_cache = reset_cache;
+        self
+    }
+
+    pub fn with_partitions(mut self, partitions: Option<usize>) -> Self {
+        self.partitions = partitions;
+        self
+    }
+
+    pub fn with_max_cache_mb(mut self, max_cache_mb: Option<usize>) -> Self {
+        self.max_cache_mb = max_cache_mb;
+        self
+    }
+
+    pub fn with_flamegraph_dir(mut self, flamegraph_dir: Option<PathBuf>) -> Self {
+        self.flamegraph_dir = flamegraph_dir;
+        self
+    }
+
+    pub fn with_query_filter(mut self, query_filter: Option<usize>) -> Self {
+        self.query_filter = query_filter;
+        self
+    }
+
+    /// Determine if a string is a file path or inline SQL
+    /// If it ends with .sql or contains path separators, treat as file path
+    /// Otherwise, treat as inline SQL
+    fn is_file_path(query_str: &str) -> bool {
+        query_str.ends_with(".sql")
+            || query_str.contains('/')
+            || query_str.contains('\\')
+            || (!query_str.contains(' ') && !query_str.contains('\n'))
+    }
+
+    async fn setup_context(
+        &self,
+        manifest: &BenchmarkManifest,
+    ) -> Result<(Arc<SessionContext>, Option<LiquidCacheRef>)> {
+        let mut session_config = SessionConfig::from_env()?;
+
+        session_config
+            .options_mut()
+            .execution
+            .parquet
+            .pushdown_filters = true;
+        if let Some(partitions) = self.partitions {
+            session_config.options_mut().execution.target_partitions = partitions;
+        }
+        session_config.options_mut().execution.batch_size = 8192 * 2;
+
+        let cache_size = self
+            .max_cache_mb
+            .map(|size| size * 1024 * 1024)
+            .unwrap_or(usize::MAX);
+
+        let cache_dir = std::env::current_dir()?.join("benchmark/data/cache");
+        if cache_dir.exists() {
+            std::fs::remove_dir_all(&cache_dir)?;
+        }
+        std::fs::create_dir_all(&cache_dir)?;
+
+        let (ctx, cache): (SessionContext, Option<LiquidCacheRef>) = match self.bench_mode {
+            InProcessBenchmarkMode::Parquet => {
+                let mut session_config = session_config.clone();
+                session_config
+                    .options_mut()
+                    .execution
+                    .parquet
+                    .pushdown_filters = false;
+                (SessionContext::new_with_config(session_config), None)
+            }
+            InProcessBenchmarkMode::Arrow => {
+                let v = LiquidCacheInProcessBuilder::new()
+                    .with_max_cache_bytes(cache_size)
+                    .with_cache_mode(LiquidCacheMode::Arrow)
+                    .with_cache_dir(cache_dir)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
+                    .build(session_config)?;
+                (v.0, Some(v.1))
+            }
+            InProcessBenchmarkMode::Liquid => {
+                let v = LiquidCacheInProcessBuilder::new()
+                    .with_max_cache_bytes(cache_size)
+                    .with_cache_mode(LiquidCacheMode::Liquid {
+                        transcode_in_background: true,
+                    })
+                    .with_cache_dir(cache_dir)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
+                    .build(session_config)?;
+                (v.0, Some(v.1))
+            }
+            InProcessBenchmarkMode::LiquidEagerTranscode => {
+                let v = LiquidCacheInProcessBuilder::new()
+                    .with_max_cache_bytes(cache_size)
+                    .with_cache_mode(LiquidCacheMode::Liquid {
+                        transcode_in_background: false,
+                    })
+                    .with_cache_dir(cache_dir)
+                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
+                    .build(session_config)?;
+                (v.0, Some(v.1))
+            }
+            InProcessBenchmarkMode::Orc => {
+                use datafusion_orc::{OrcReadOptions, SessionContextOrcExt};
+
+                let ctx = SessionContext::new_with_config(session_config);
+                // Register ORC tables
+                for (table_name, table_path) in &manifest.tables {
+                    if table_path.ends_with(".orc") {
+                        ctx.register_orc(table_name, table_path, OrcReadOptions::default())
+                            .await?;
+                        info!("Registered ORC table '{}' from {}", table_name, table_path);
+                    }
+                }
+                (ctx, None)
+            }
+        };
+
+        // Register object stores if configured
+        if let Some(object_stores) = &manifest.object_stores {
+            for store_config in object_stores {
+                let url = ObjectStoreUrl::parse(&store_config.url)?;
+                let options = store_config.options.clone().unwrap_or_default();
+
+                let (object_store, _) = object_store::parse_url_opts(url.as_ref(), options)?;
+                ctx.register_object_store(url.as_ref(), Arc::new(object_store));
+                info!("Registered object store: {}", store_config.url);
+            }
+        }
+
+        // Register tables from manifest (skip ORC tables if already registered)
+        for (table_name, table_path_str) in &manifest.tables {
+            if !table_path_str.ends_with(".orc") {
+                ctx.register_parquet(table_name, table_path_str, Default::default())
+                    .await?;
+                info!("Registered table '{}' from {}", table_name, table_path_str);
+            }
+        }
+
+        Ok((Arc::new(ctx), cache))
+    }
+
+    async fn load_queries(&self, manifest: &BenchmarkManifest) -> Result<Vec<Query>> {
+        let mut queries = Vec::new();
+
+        for (index, query_str) in manifest.queries.iter().enumerate() {
+            let sql = if Self::is_file_path(query_str) {
+                // Treat as file path
+                let sql = std::fs::read_to_string(query_str)?;
+                info!("Loaded query {} from file: {}", index, query_str);
+                sql
+            } else {
+                // Treat as inline SQL
+                info!("Loaded query {} from inline SQL", index);
+                query_str.clone()
+            };
+
+            queries.push(Query {
+                id: index as u32,
+                sql,
+            });
+        }
+
+        Ok(queries)
+    }
+
+    async fn execute_query(
+        &self,
+        ctx: &Arc<SessionContext>,
+        query: &Query,
+        manifest: &BenchmarkManifest,
+    ) -> Result<(
+        Vec<datafusion::arrow::array::RecordBatch>,
+        Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    )> {
+        // Check for special query handling
+        if let Some(special_handling) = &manifest.special_query_handling {
+            if let Some(handling_type) = special_handling.get(&query.id) {
+                if handling_type == "tpch_q15" && query.id == 15 {
+                    // Q15 has three queries, the second one is the one we want to test
+                    let queries: Vec<&str> = query.sql.split(';').collect();
+                    let mut results = Vec::new();
+                    let mut plan = None;
+                    for (i, q) in queries.iter().enumerate() {
+                        let (result, p, _) = run_query(ctx, q).await?;
+                        if i == 1 {
+                            results = result;
+                            plan = Some(p);
+                        }
+                    }
+                    return Ok((results, plan.unwrap()));
+                }
+            }
+        }
+
+        let (results, plan, _) = run_query(ctx, &query.sql).await?;
+        Ok((results, plan))
+    }
+
+    fn write_flamegraph(
+        &self,
+        profiler: &pprof::ProfilerGuard,
+        query_id: u32,
+        iteration: u32,
+    ) -> Result<()> {
+        if let Some(flamegraph_dir) = &self.flamegraph_dir {
+            let report = profiler.report().build()?;
+            let mut svg_data = Vec::new();
+            report.flamegraph(&mut svg_data)?;
+            create_dir_all(flamegraph_dir)?;
+
+            let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?;
+            let secs = now.as_secs();
+            let hour = (secs / 3600) % 24;
+            let minute = (secs / 60) % 60;
+            let second = secs % 60;
+
+            let filename = format!(
+                "{:02}h{:02}m{:02}s_q{}_i{}.svg",
+                hour, minute, second, query_id, iteration
+            );
+            let filepath = flamegraph_dir.join(filename);
+            std::fs::write(&filepath, svg_data)?;
+            info!("Flamegraph written to: {}", filepath.display());
+        }
+        Ok(())
+    }
+
+    async fn run_single_iteration(
+        &self,
+        ctx: &Arc<SessionContext>,
+        query: &Query,
+        manifest: &BenchmarkManifest,
+        bench_start_time: Instant,
+        cache: Option<LiquidCacheRef>,
+        iteration: u32,
+    ) -> Result<IterationResult> {
+        info!(
+            "Running query {} iteration {}: \n{}",
+            query.id, iteration, query.sql
+        );
+
+        // Start flamegraph profiling if enabled
+        let profiler_guard = if self.flamegraph_dir.is_some() {
+            Some(
+                pprof::ProfilerGuardBuilder::default()
+                    .frequency(500)
+                    .blocklist(&["libpthread.so.0", "libm.so.6", "libgcc_s.so.1"])
+                    .build()?,
+            )
+        } else {
+            None
+        };
+
+        // Capture disk I/O metrics before query execution
+        let mut disk_info = Disks::new_with_refreshed_list();
+
+        let now = Instant::now();
+        let starting_timestamp = bench_start_time.elapsed();
+
+        let (_results, _execution_plan) = self.execute_query(ctx, query, manifest).await?;
+        let elapsed = now.elapsed();
+
+        disk_info.refresh(true);
+        let disk_read: u64 = disk_info.iter().map(|disk| disk.usage().read_bytes).sum();
+        let disk_written: u64 = disk_info
+            .iter()
+            .map(|disk| disk.usage().written_bytes)
+            .sum();
+
+        // Stop flamegraph profiling and write to file if enabled
+        if let Some(profiler) = profiler_guard {
+            self.write_flamegraph(&profiler, query.id, iteration)?;
+        }
+
+        let cache_memory_usage = if let Some(cache) = cache {
+            cache.memory_usage_bytes()
+        } else {
+            0
+        };
+
+        let result = IterationResult {
+            network_traffic: 0,
+            time_millis: elapsed.as_millis() as u64,
+            cache_cpu_time: 0, // Not easily available for in-process
+            cache_memory_usage: cache_memory_usage as u64,
+            liquid_cache_usage: cache_memory_usage as u64,
+            disk_bytes_read: disk_read,
+            disk_bytes_written: disk_written,
+            starting_timestamp,
+        };
+
+        info!("\n{result}");
+        Ok(result)
+    }
+
+    pub async fn run<T: Serialize + Clone>(
+        self,
+        manifest: BenchmarkManifest,
+        benchmark_args: T,
+        output_path: Option<PathBuf>,
+    ) -> Result<BenchmarkResult<T>> {
+        info!("Running benchmark: {}", manifest.name);
+
+        let (ctx, cache) = self.setup_context(&manifest).await?;
+        let queries = self.load_queries(&manifest).await?;
+
+        // Filter queries if specific query index is requested
+        let query_indices: Vec<usize> = if let Some(query_index) = self.query_filter {
+            if query_index >= queries.len() {
+                return Err(anyhow::anyhow!(
+                    "Query index {} out of range (max: {})",
+                    query_index,
+                    queries.len() - 1
+                ));
+            }
+            vec![query_index]
+        } else {
+            (0..queries.len()).collect()
+        };
+
+        let mut benchmark_result = BenchmarkResult {
+            args: benchmark_args,
+            results: Vec::new(),
+        };
+
+        let bench_start_time = Instant::now();
+
+        for query_index in query_indices {
+            let query = &queries[query_index];
+            let mut query_result = QueryResult::new(query.id, query.sql.clone());
+
+            for it in 0..self.iteration {
+                let iteration_result = self
+                    .run_single_iteration(
+                        &ctx,
+                        query,
+                        &manifest,
+                        bench_start_time,
+                        cache.clone(),
+                        it + 1,
+                    )
+                    .await?;
+
+                query_result.add(iteration_result);
+
+                if self.reset_cache
+                    && let Some(cache) = &cache
+                {
+                    cache.reset();
+                }
+            }
+
+            benchmark_result.results.push(query_result);
+        }
+
+        if let Some(output_path) = &output_path {
+            let output_file = File::create(output_path)?;
+            serde_json::to_writer_pretty(output_file, &benchmark_result)?;
+        }
+
+        Ok(benchmark_result)
+    }
+}

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -17,15 +17,15 @@ use std::time::Duration;
 use std::{fmt::Display, str::FromStr, sync::Arc};
 use uuid::Uuid;
 
+pub mod inprocess;
 mod observability;
 pub mod runner;
 pub mod tpch;
 pub mod utils;
-pub mod inprocess;
 
+pub use inprocess::*;
 pub use observability::*;
 pub use runner::*;
-pub use inprocess::*;
 
 pub struct Query {
     pub id: u32,

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -409,17 +409,22 @@ pub struct IterationResult {
     pub cache_memory_usage: u64,
     pub liquid_cache_usage: u64,
     pub starting_timestamp: Duration,
+    pub disk_bytes_read: u64,
+    pub disk_bytes_written: u64,
 }
 
-impl IterationResult {
-    pub fn log(&self) {
-        info!(
-            "Query: {} ms, network: {} bytes, cache cpu time: {} ms, cache memory: {} bytes, liquid cache memory: {} bytes",
+impl Display for IterationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Query time: {} ms\n network: {} bytes\n cache cpu time: {} ms\n cache memory: {} bytes, liquid cache memory: {} bytes\n disk read: {} bytes, disk written: {} bytes",
             self.time_millis,
             self.network_traffic,
             self.cache_cpu_time,
             self.cache_memory_usage,
-            self.liquid_cache_usage
-        );
+            self.liquid_cache_usage,
+            self.disk_bytes_read,
+            self.disk_bytes_written,
+        )
     }
 }

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -21,9 +21,11 @@ mod observability;
 pub mod runner;
 pub mod tpch;
 pub mod utils;
+pub mod inprocess;
 
 pub use observability::*;
 pub use runner::*;
+pub use inprocess::*;
 
 pub struct Query {
     pub id: u32,

--- a/benchmark/tpch/tpch_inprocess.rs
+++ b/benchmark/tpch/tpch_inprocess.rs
@@ -1,15 +1,12 @@
+use anyhow::Result;
 use clap::Parser;
 use liquid_cache_benchmarks::{
-    setup_observability, tpch, BenchmarkManifest, InProcessBenchmarkMode, InProcessBenchmarkRunner,
+    BenchmarkManifest, InProcessBenchmarkMode, InProcessBenchmarkRunner, setup_observability, tpch,
 };
 use mimalloc::MiMalloc;
 use serde::Serialize;
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-};
+use std::{collections::HashMap, path::PathBuf};
 use url::Url;
-use anyhow::Result;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -85,14 +82,15 @@ impl TpchInProcessBenchmark {
                     current_dir,
                     self.data_dir.display(),
                     table_name
-                ))?.to_string()
+                ))?
+                .to_string()
             };
             manifest = manifest.add_table(table_name.to_string(), table_path);
         }
 
         // Load queries from TPC-H directory
         let queries = tpch::get_all_queries(&self.query_dir)?;
-        
+
         // Filter to relevant queries if no specific query is requested
         let query_filter: Vec<u32> = if let Some(query) = self.query {
             vec![query]
@@ -119,7 +117,7 @@ impl TpchInProcessBenchmark {
 
     pub async fn run(self) -> Result<()> {
         let manifest = self.generate_manifest()?;
-        
+
         // Convert query number to query index for the runner
         let query_filter = if let Some(query_num) = self.query {
             // Find the index of the requested query in the relevant queries
@@ -135,7 +133,7 @@ impl TpchInProcessBenchmark {
         let max_cache_mb = self.max_cache_mb;
         let flamegraph_dir = self.flamegraph_dir.clone();
         let output = self.output.clone();
-        
+
         let runner = InProcessBenchmarkRunner::new()
             .with_bench_mode(bench_mode)
             .with_iteration(iteration)

--- a/benchmark/tpch/tpch_inprocess.rs
+++ b/benchmark/tpch/tpch_inprocess.rs
@@ -1,59 +1,20 @@
 use clap::Parser;
-use datafusion::catalog::memory::DataSourceExec;
-use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
-use datafusion::physical_plan::ExecutionPlan;
-use datafusion::physical_plan::metrics::MetricValue;
-use datafusion::prelude::SessionConfig;
-use datafusion::{arrow::array::RecordBatch, error::Result, prelude::SessionContext};
-use datafusion_orc::{OrcReadOptions, SessionContextOrcExt};
-use liquid_cache_benchmarks::{Query, run_query, setup_observability, tpch};
-use liquid_cache_common::{CacheEvictionStrategy, LiquidCacheMode};
-use liquid_cache_parquet::{LiquidCacheInProcessBuilder, LiquidCacheRef};
-use log::info;
+use liquid_cache_benchmarks::{
+    setup_observability, tpch, BenchmarkManifest, InProcessBenchmarkMode, InProcessBenchmarkRunner,
+};
 use mimalloc::MiMalloc;
 use serde::Serialize;
 use std::{
-    fs::{File, create_dir_all},
+    collections::HashMap,
     path::PathBuf,
-    sync::Arc,
-    time::{Duration, Instant},
 };
-use sysinfo::Disks;
 use url::Url;
+use anyhow::Result;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
 const RELEVANT_QUERIES: &[u32] = &[4, 6, 11, 12, 14, 15, 16, 20];
-
-#[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Serialize)]
-enum BenchmarkMode {
-    Parquet,
-    Arrow,
-    #[default]
-    Liquid,
-    LiquidEagerTranscode,
-    Orc,
-}
-
-impl std::str::FromStr for BenchmarkMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "parquet" => BenchmarkMode::Parquet,
-            "arrow" => BenchmarkMode::Arrow,
-            "liquid" => BenchmarkMode::Liquid,
-            "liquid-eager-transcode" => BenchmarkMode::LiquidEagerTranscode,
-            "orc" => BenchmarkMode::Orc,
-            _ => {
-                return Err(format!(
-                    "Invalid in-process benchmark mode: {s}, must be one of: parquet, arrow, liquid, liquid-eager-transcode, orc"
-                ));
-            }
-        })
-    }
-}
 
 #[derive(Parser, Serialize, Clone)]
 #[command(name = "TPCH In-Process Benchmark")]
@@ -68,7 +29,7 @@ struct TpchInProcessBenchmark {
 
     /// Benchmark mode to use
     #[arg(long = "bench-mode", default_value = "liquid-eager-transcode")]
-    pub bench_mode: BenchmarkMode,
+    pub bench_mode: InProcessBenchmarkMode,
 
     /// Number of times to run each query
     #[arg(long, default_value = "3")]
@@ -99,325 +60,93 @@ struct TpchInProcessBenchmark {
     pub flamegraph_dir: Option<PathBuf>,
 }
 
-#[derive(Serialize)]
-pub struct BenchmarkResult {
-    args: TpchInProcessBenchmark,
-    results: Vec<QueryResult>,
-}
-
-#[derive(Serialize)]
-pub struct QueryResult {
-    id: u32,
-    query: String,
-    iteration_results: Vec<IterationResult>,
-}
-
-impl QueryResult {
-    pub fn new(id: u32, query: String) -> Self {
-        Self {
-            id,
-            query,
-            iteration_results: Vec::new(),
-        }
-    }
-
-    pub fn add(&mut self, iteration_result: IterationResult) {
-        self.iteration_results.push(iteration_result);
-    }
-}
-
-#[derive(Serialize)]
-pub struct IterationResult {
-    pub time_millis: u64,
-    pub cache_memory_usage: u64,
-    pub starting_timestamp: Duration,
-    pub bytes_read: u64,
-    pub bytes_written: u64,
-}
-
-impl IterationResult {
-    pub fn log(&self) {
-        info!(
-            "Query: {} ms, cache memory: {} bytes, disk I/O: read {} bytes, written {} bytes",
-            self.time_millis, self.cache_memory_usage, self.bytes_read, self.bytes_written,
-        );
-    }
-}
-
 impl TpchInProcessBenchmark {
-    async fn setup_context(&self) -> Result<(Arc<SessionContext>, Option<LiquidCacheRef>)> {
-        let mut session_config = SessionConfig::from_env()?;
+    fn generate_manifest(&self) -> Result<BenchmarkManifest> {
         let current_dir = std::env::current_dir()?.to_string_lossy().to_string();
-
         let tables = [
             "customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier",
         ];
 
-        session_config
-            .options_mut()
-            .execution
-            .parquet
-            .pushdown_filters = true;
-        if let Some(partitions) = self.partitions {
-            session_config.options_mut().execution.target_partitions = partitions;
-        }
-        session_config.options_mut().execution.batch_size = 8192 * 2;
-        let cache_size = self
-            .max_cache_mb
-            .map(|size| size * 1024 * 1024)
-            .unwrap_or(usize::MAX);
+        let mut manifest = BenchmarkManifest::new("TPC-H In-Process Benchmark".to_string())
+            .with_description("TPC-H benchmark using in-process liquid cache".to_string());
 
-        let cache_dir = std::env::current_dir()?.join("benchmark/tpch/data/cache");
-        if cache_dir.exists() {
-            std::fs::remove_dir_all(&cache_dir)?;
-        }
-        std::fs::create_dir_all(&cache_dir)?;
-        let (ctx, cache): (SessionContext, Option<LiquidCacheRef>) = match self.bench_mode {
-            BenchmarkMode::Parquet => (SessionContext::new_with_config(session_config), None),
-            BenchmarkMode::Arrow => {
-                let v = LiquidCacheInProcessBuilder::new()
-                    .with_max_cache_bytes(cache_size)
-                    .with_cache_mode(LiquidCacheMode::Arrow)
-                    .with_cache_dir(cache_dir)
-                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
-                    .build(session_config)?;
-                (v.0, Some(v.1))
-            }
-            BenchmarkMode::Liquid => {
-                let v = LiquidCacheInProcessBuilder::new()
-                    .with_max_cache_bytes(cache_size)
-                    .with_cache_mode(LiquidCacheMode::Liquid {
-                        transcode_in_background: true,
-                    })
-                    .with_cache_dir(cache_dir)
-                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
-                    .build(session_config)?;
-                (v.0, Some(v.1))
-            }
-            BenchmarkMode::LiquidEagerTranscode => {
-                let v = LiquidCacheInProcessBuilder::new()
-                    .with_max_cache_bytes(cache_size)
-                    .with_cache_mode(LiquidCacheMode::Liquid {
-                        transcode_in_background: false,
-                    })
-                    .with_cache_dir(cache_dir)
-                    .with_cache_strategy(CacheEvictionStrategy::ToDisk)
-                    .build(session_config)?;
-                (v.0, Some(v.1))
-            }
-            BenchmarkMode::Orc => (SessionContext::new_with_config(session_config), None),
-        };
+        // Add tables based on benchmark mode
         for table_name in tables.iter() {
-            match self.bench_mode {
-                BenchmarkMode::Orc => {
-                    let table_path = format!(
-                        "file://{}/{}/{}.orc",
-                        current_dir,
-                        self.data_dir.display(),
-                        table_name
-                    );
-                    ctx.register_orc(table_name, &table_path, OrcReadOptions::default())
-                        .await?;
-                }
-                _ => {
-                    let table_path = Url::parse(&format!(
-                        "file://{}/{}/{}.parquet",
-                        current_dir,
-                        self.data_dir.display(),
-                        table_name
-                    ))
-                    .unwrap();
-                    ctx.register_parquet(*table_name, table_path, Default::default())
-                        .await?;
-                }
-            }
+            let table_path = if self.bench_mode == InProcessBenchmarkMode::Orc {
+                format!(
+                    "file://{}/{}/{}.orc",
+                    current_dir,
+                    self.data_dir.display(),
+                    table_name
+                )
+            } else {
+                Url::parse(&format!(
+                    "file://{}/{}/{}.parquet",
+                    current_dir,
+                    self.data_dir.display(),
+                    table_name
+                ))?.to_string()
+            };
+            manifest = manifest.add_table(table_name.to_string(), table_path);
         }
 
-        Ok((Arc::new(ctx), cache))
-    }
-
-    async fn get_queries(&self) -> Result<Vec<Query>> {
-        tpch::get_all_queries(&self.query_dir)
-    }
-
-    async fn execute_query(
-        &self,
-        ctx: &Arc<SessionContext>,
-        query: &Query,
-    ) -> Result<(Vec<RecordBatch>, Arc<dyn ExecutionPlan>)> {
-        if query.id == 15 {
-            // Q15 has three queries, the second one is the one we want to test
-            let queries: Vec<&str> = query.sql.split(';').collect();
-            let mut results = Vec::new();
-            let mut plan = None;
-            for (i, q) in queries.iter().enumerate() {
-                let (result, p, _) = run_query(ctx, q).await?;
-                if i == 1 {
-                    results = result;
-                    plan = Some(p);
-                }
-            }
-            Ok((results, plan.unwrap()))
+        // Load queries from TPC-H directory
+        let queries = tpch::get_all_queries(&self.query_dir)?;
+        
+        // Filter to relevant queries if no specific query is requested
+        let query_filter: Vec<u32> = if let Some(query) = self.query {
+            vec![query]
         } else {
-            let (results, plan, _) = run_query(ctx, &query.sql).await?;
-            Ok((results, plan))
+            RELEVANT_QUERIES.to_vec()
+        };
+
+        for query in queries {
+            if query_filter.contains(&query.id) {
+                // For TPC-H, we add the query SQL directly as inline SQL
+                manifest = manifest.add_query(query.sql);
+            }
         }
+
+        // Add special handling for Q15
+        if query_filter.contains(&15) {
+            let mut special_handling = HashMap::new();
+            special_handling.insert(15, "tpch_q15".to_string());
+            manifest = manifest.with_special_query_handling(special_handling);
+        }
+
+        Ok(manifest)
     }
 
-    async fn run_single_iteration(
-        &self,
-        ctx: &Arc<SessionContext>,
-        query: &Query,
-        bench_start_time: Instant,
-        cache: Option<LiquidCacheRef>,
-        iteration: u32,
-    ) -> Result<IterationResult> {
-        info!("Running query {}: \n{}", query.id, query.sql);
-
-        // Start flamegraph profiling if enabled
-        let profiler_guard = if self.flamegraph_dir.is_some() {
-            Some(
-                pprof::ProfilerGuardBuilder::default()
-                    .frequency(500)
-                    .blocklist(&["libpthread.so.0", "libm.so.6", "libgcc_s.so.1"])
-                    .build()
-                    .unwrap(),
-            )
+    pub async fn run(self) -> Result<()> {
+        let manifest = self.generate_manifest()?;
+        
+        // Convert query number to query index for the runner
+        let query_filter = if let Some(query_num) = self.query {
+            // Find the index of the requested query in the relevant queries
+            RELEVANT_QUERIES.iter().position(|&q| q == query_num)
         } else {
             None
         };
 
-        // Capture disk I/O metrics before query execution
-        let mut disk_info = Disks::new_with_refreshed_list();
+        let bench_mode = self.bench_mode;
+        let iteration = self.iteration;
+        let reset_cache = self.reset_cache;
+        let partitions = self.partitions;
+        let max_cache_mb = self.max_cache_mb;
+        let flamegraph_dir = self.flamegraph_dir.clone();
+        let output = self.output.clone();
+        
+        let runner = InProcessBenchmarkRunner::new()
+            .with_bench_mode(bench_mode)
+            .with_iteration(iteration)
+            .with_reset_cache(reset_cache)
+            .with_partitions(partitions)
+            .with_max_cache_mb(max_cache_mb)
+            .with_flamegraph_dir(flamegraph_dir)
+            .with_query_filter(query_filter);
 
-        let now = Instant::now();
-        let starting_timestamp = bench_start_time.elapsed();
-
-        let (_results, execution_plan) = self.execute_query(ctx, query).await?;
-        let elapsed = now.elapsed();
-
-        disk_info.refresh(true);
-        let disk_read: u64 = disk_info.iter().map(|disk| disk.usage().read_bytes).sum();
-
-        let disk_written: u64 = disk_info
-            .iter()
-            .map(|disk| disk.usage().written_bytes)
-            .sum();
-
-        // Stop flamegraph profiling and write to file if enabled
-        if let Some(profiler) = profiler_guard
-            && let Some(flamegraph_dir) = &self.flamegraph_dir
-        {
-            let report = profiler.report().build().unwrap();
-            let mut svg_data = Vec::new();
-            report.flamegraph(&mut svg_data).unwrap();
-            create_dir_all(flamegraph_dir)?;
-
-            // Get current time for filename prefix
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap();
-            let secs = now.as_secs();
-            let hour = (secs / 3600) % 24;
-            let minute = (secs / 60) % 60;
-            let second = secs % 60;
-
-            let filename = format!(
-                "{:02}h{:02}m{:02}s_q{}_i{}.svg",
-                hour, minute, second, query.id, iteration
-            );
-            let filepath = flamegraph_dir.join(filename);
-            std::fs::write(&filepath, svg_data).unwrap();
-            info!("Flamegraph written to: {}", filepath.display());
-        }
-
-        let cache_memory_usage = if let Some(cache) = cache {
-            cache.memory_usage_bytes()
-        } else {
-            let mut total_bytes_scanned = 0;
-            let _ = execution_plan
-                .apply(|plan| {
-                    if plan.as_any().downcast_ref::<DataSourceExec>().is_some() {
-                        let metrics = plan
-                            .metrics()
-                            .unwrap()
-                            .aggregate_by_name()
-                            .sorted_for_display()
-                            .timestamps_removed();
-
-                        for metric in metrics.iter() {
-                            if let MetricValue::Count { name, count } = metric.value()
-                                && name == "bytes_scanned"
-                            {
-                                total_bytes_scanned += count.value();
-                            }
-                        }
-                    }
-                    Ok(TreeNodeRecursion::Continue)
-                })
-                .unwrap();
-            total_bytes_scanned
-        };
-
-        let result = IterationResult {
-            time_millis: elapsed.as_millis() as u64,
-            cache_memory_usage: cache_memory_usage as u64,
-            starting_timestamp,
-            bytes_read: disk_read,
-            bytes_written: disk_written,
-        };
-
-        result.log();
-        Ok(result)
-    }
-
-    pub async fn run(self) -> Result<BenchmarkResult> {
-        let (ctx, cache) = self.setup_context().await?;
-        let queries = self.get_queries().await?;
-        let queries = if let Some(query) = self.query {
-            vec![queries.into_iter().find(|q| q.id == query).unwrap()]
-        } else {
-            queries
-                .into_iter()
-                .filter(|q| RELEVANT_QUERIES.contains(&q.id))
-                .collect()
-        };
-
-        let mut benchmark_result = BenchmarkResult {
-            args: self.clone(),
-            results: Vec::new(),
-        };
-
-        std::fs::create_dir_all("benchmark/data/results")?;
-
-        let bench_start_time = Instant::now();
-
-        for query in queries {
-            let mut query_result = QueryResult::new(query.id, query.sql.clone());
-
-            for it in 0..self.iteration {
-                let iteration_result = self
-                    .run_single_iteration(&ctx, &query, bench_start_time, cache.clone(), it + 1)
-                    .await?;
-
-                query_result.add(iteration_result);
-            }
-
-            if self.reset_cache
-                && let Some(cache) = &cache
-            {
-                cache.reset();
-            }
-
-            benchmark_result.results.push(query_result);
-        }
-
-        if let Some(output_path) = &self.output {
-            let output_file = File::create(output_path)?;
-            serde_json::to_writer_pretty(output_file, &benchmark_result).unwrap();
-        }
-
-        Ok(benchmark_result)
+        runner.run(manifest, self, output).await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Introduce the concept of manifest file:

```json
{
  "name": "My Benchmark Suite",
  "description": "Description of what this benchmark tests",
  "tables": {
    "table1": "data/table1.parquet",
    "table2": "data/table2.parquet"
  },
  "queries": [
    "queries/aggregation.sql",
    "SELECT COUNT(*) FROM table1 WHERE col > 100",
    "queries/complex_join.sql",
    "SELECT t1.id, t2.name FROM table1 t1 JOIN table2 t2 ON t1.id = t2.id LIMIT 10"
  ],
  "object_stores": [
    {
      "url": "s3://my-bucket",
      "options": {
        "aws_access_key_id": "my-access-key",
        "aws_secret_access_key": "my-secret-key",
        "aws_region": "us-west-2"
      }
    }
  ]
}
```

(Will be our own lake house format?)