### PR TITLE
Add MockStore metrics and LocalCache interaction tests

### DIFF
--- a/src/server/src/local_cache.rs
+++ b/src/server/src/local_cache.rs
@@ -300,6 +300,7 @@ impl ObjectStore for LocalCache {
 mod tests {
     use super::*;
     use bytes::Bytes;
+    use liquid_cache_common::mock_store::MockStore;
     use object_store::memory::InMemory;
     use std::ops::Range;
     use tempfile::tempdir;
@@ -565,6 +566,34 @@ mod tests {
         // Additional verification - check if a specific range is read correctly
         let mid_range = file_size / 2;
         verify_range(&second_cache, file_path, mid_range..mid_range + 1024).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_object_store_metrics() -> Result<()> {
+        let inner = Arc::new(MockStore::new_with_files(
+            1,
+            (CACHE_BLOCK_SIZE * 3) as usize,
+        ));
+        let temp_dir = tempdir().unwrap();
+        let cache = LocalCache::new(inner.clone(), temp_dir.path().to_path_buf());
+
+        let path = Path::from("0.parquet");
+        let start = CACHE_BLOCK_SIZE / 2;
+        let end = CACHE_BLOCK_SIZE + CACHE_BLOCK_SIZE / 2;
+
+        verify_range(&cache, path.as_ref(), start..end).await?;
+
+        let ranges = inner.get_access_ranges(&path).unwrap();
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0], 0..CACHE_BLOCK_SIZE);
+        assert_eq!(ranges[1], CACHE_BLOCK_SIZE..CACHE_BLOCK_SIZE * 2);
+
+        // second request should hit cache and not increase range count
+        verify_range(&cache, path.as_ref(), start + 1024..end - 1024).await?;
+        let ranges_after = inner.get_access_ranges(&path).unwrap();
+        assert_eq!(ranges_after.len(), 2);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- enhance `MockStore` with logging of requested ranges
- expose `get_access_ranges` for test assertions
- add integration test verifying server prefetch uses expected ranges

## Testing
- `cargo test -p liquid-cache-server local_cache::tests::test_object_store_metrics -- --nocapture`
- `cargo test -p liquid-cache-common --lib --quiet`
- `cargo test -p liquid-cache-server --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68522a8483a4833291e6e89a6a9a8896