### PR TITLE
ci: add standalone docker release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,53 @@
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag for the Docker image'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  publish-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build binary
+        run: cargo build --release --bin bench_server
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ env.OWNER_LC }}/liquid-cache/liquid-cache-server:latest,ghcr.io/${{ env.OWNER_LC }}/liquid-cache/liquid-cache-server:v${{ inputs.version }}
+          file: dev/liquid_cache_server.dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
       contents: write
       pull-requests: write
       packages: write
+    outputs:
+      new_version: ${{ steps.release.outputs.new_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -99,30 +101,6 @@ jobs:
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build binary
-        run: cargo build --release --bin bench_server
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set lower case owner name
-        run: |
-          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
-        env:
-          OWNER: '${{ github.repository_owner }}'
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/${{ env.OWNER_LC }}/liquid-cache/liquid-cache-server:latest,ghcr.io/${{ env.OWNER_LC }}/liquid-cache/liquid-cache-server:v${{ steps.release.outputs.new_version }}
-          file: dev/liquid_cache_server.dockerfile
-
       - name: Create Pull Request
         id: create_pr
         uses: peter-evans/create-pull-request@v7
@@ -137,5 +115,12 @@ jobs:
           commit-message: "chore: prepare release v${{ steps.release.outputs.new_version }}"
           delete-branch: true
 
-      - name: Output PR URL
-        run: echo "Pull request created at ${{ steps.create_pr.outputs.pull-request-url }}"
+        - name: Output PR URL
+          run: echo "Pull request created at ${{ steps.create_pr.outputs.pull-request-url }}"
+
+  publish-docker:
+    needs: release-and-publish
+    uses: ./.github/workflows/docker-release.yml
+    with:
+      version: ${{ needs.release-and-publish.outputs.new_version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- separate docker build & push into its own workflow
- remove docker steps from crate publish workflow
- trigger docker release after crates.io publishing

## Testing
- `cargo test` *(fails: E0658 `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_e_689b55b753108332b26bb2a8806ed3e2