### PR TITLE
Implement variant support in liquid cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,6 +2986,8 @@ dependencies = [
  "num-traits",
  "object_store",
  "parquet",
+ "parquet-variant",
+ "parquet-variant-compute",
  "paste",
  "rand 0.9.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ parquet = { version = "57.0.0", features = [
 	"variant_experimental",
 ] }
 parquet-variant-json = { version = "0.2.0" }
+parquet-variant = { version = "0.2.0" }
+parquet-variant-compute = { version = "0.2.0" }
 datafusion = { version = "51.0.0" }
 datafusion-proto = { version = "51.0.0" }
 async-trait = "0.1.89"
@@ -89,3 +91,5 @@ arrow-select = { git = "https://github.com/apache/arrow-rs.git", branch = "main"
 arrow-flight = { git = "https://github.com/apache/arrow-rs.git", branch = "main" }
 parquet = { git = "https://github.com/apache/arrow-rs.git", branch = "main" }
 parquet-variant-json = { git = "https://github.com/apache/arrow-rs.git", branch = "main" }
+parquet-variant = { git = "https://github.com/apache/arrow-rs.git", branch = "main" }
+parquet-variant-compute = { git = "https://github.com/apache/arrow-rs.git", branch = "main" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -27,6 +27,8 @@ tempfile = { workspace = true }
 congee = { workspace = true }
 log = { workspace = true }
 parquet = { workspace = true }
+parquet-variant = { workspace = true }
+parquet-variant-compute = { workspace = true }
 fastrace = { workspace = true }
 
 [dev-dependencies]

--- a/src/storage/src/cache/expressions.rs
+++ b/src/storage/src/cache/expressions.rs
@@ -1,68 +1,21 @@
 //! Definitions for cache-aware expressions that can be applied when materializing arrays.
 
+use std::sync::Arc;
+
 use crate::liquid_array::Date32Field;
 
-/// Compact identifier for cache expressions, encoded into a `u16`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CacheExpressionId(pub u16);
-
-impl CacheExpressionId {
-    const KIND_SHIFT: u16 = 8;
-    const KIND_MASK: u16 = 0xFF;
-    const VARIANT_MASK: u16 = 0xFF;
-
-    const KIND_EXTRACT_DATE32: u16 = 1;
-
-    /// Build an identifier for extracting a specific `Date32` component.
-    pub const fn from_date32_field(field: Date32Field) -> Self {
-        let variant = match field {
-            Date32Field::Year => 0,
-            Date32Field::Month => 1,
-            Date32Field::Day => 2,
-        };
-        let raw = (Self::KIND_EXTRACT_DATE32 << Self::KIND_SHIFT) | variant;
-        Self(raw)
-    }
-
-    /// Create an identifier directly from its raw `u16` value.
-    pub const fn from_raw(raw: u16) -> Self {
-        Self(raw)
-    }
-
-    /// Return the raw `u16` backing this identifier.
-    pub const fn raw(self) -> u16 {
-        self.0
-    }
-
-    const fn kind(self) -> u16 {
-        (self.0 >> Self::KIND_SHIFT) & Self::KIND_MASK
-    }
-
-    const fn variant(self) -> u16 {
-        self.0 & Self::VARIANT_MASK
-    }
-
-    /// Interpret this identifier as a `Date32` extract expression, if applicable.
-    pub const fn as_date32_field(self) -> Option<Date32Field> {
-        if self.kind() != Self::KIND_EXTRACT_DATE32 {
-            return None;
-        }
-        match self.variant() {
-            0 => Some(Date32Field::Year),
-            1 => Some(Date32Field::Month),
-            2 => Some(Date32Field::Day),
-            _ => None,
-        }
-    }
-}
-
 /// Experimental expression descriptor for cache lookups.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CacheExpression {
     /// Extract a specific component (YEAR/MONTH/DAY) from a `Date32` column.
     ExtractDate32 {
         /// Component to extract (YEAR/MONTH/DAY).
         field: Date32Field,
+    },
+    /// Extract a field from a variant column via `variant_get`.
+    VariantGet {
+        /// The dotted path requested by the query.
+        path: Arc<str>,
     },
 }
 
@@ -70,6 +23,11 @@ impl CacheExpression {
     /// Build an extract expression for a `Date32` column.
     pub fn extract_date32(field: Date32Field) -> Self {
         Self::ExtractDate32 { field }
+    }
+
+    /// Build a variant-get expression for the provided dotted path.
+    pub fn variant_get(path: impl Into<Arc<str>>) -> Self {
+        Self::VariantGet { path: path.into() }
     }
 
     /// Attempt to parse a metadata value (e.g. `"YEAR"`) into an expression.
@@ -90,13 +48,15 @@ impl CacheExpression {
     pub fn as_date32_field(&self) -> Option<Date32Field> {
         match self {
             Self::ExtractDate32 { field } => Some(*field),
+            Self::VariantGet { .. } => None,
         }
     }
 
-    /// Encode this expression into a compact identifier.
-    pub fn hint_id(&self) -> CacheExpressionId {
+    /// Return the associated variant path when this is a variant-get expression.
+    pub fn variant_path(&self) -> Option<&str> {
         match self {
-            Self::ExtractDate32 { field } => CacheExpressionId::from_date32_field(*field),
+            Self::VariantGet { path } => Some(path.as_ref()),
+            Self::ExtractDate32 { .. } => None,
         }
     }
 }

--- a/src/storage/src/cache/mod.rs
+++ b/src/storage/src/cache/mod.rs
@@ -18,7 +18,7 @@ pub use core::{
     BlockingIoContext, CacheStorage, CacheStorageBuilder, DefaultIoContext, EvaluatePredicate, Get,
     Insert, IoContext,
 };
-pub use expressions::{CacheExpression, CacheExpressionId};
+pub use expressions::CacheExpression;
 pub use stats::{CacheStats, RuntimeStats, RuntimeStatsSnapshot};
 pub use transcode::transcode_liquid_inner;
 pub use utils::{EntryID, LiquidCompressorStates};

--- a/src/storage/src/cache/squeeze_policies.rs
+++ b/src/storage/src/cache/squeeze_policies.rs
@@ -1,13 +1,20 @@
 //! Squeeze policies for liquid cache.
 
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, StructArray};
+use arrow_schema::{DataType, Field};
 use bytes::Bytes;
+use parquet_variant::VariantPath;
+use parquet_variant_compute::{GetOptions, VariantArray, variant_get};
 
 use crate::cache::{
-    LiquidCompressorStates,
+    CacheExpression, LiquidCompressorStates,
     cached_batch::{CacheEntry, CachedData},
     transcode_liquid_inner,
     utils::arrow_to_bytes,
 };
+use crate::liquid_array::{LiquidHybridArrayRef, VariantExtractedArray};
 
 /// What to do when we need to squeeze an entry?
 pub trait SqueezePolicy: std::fmt::Debug + Send + Sync {
@@ -81,25 +88,40 @@ impl SqueezePolicy for TranscodeSqueezeEvict {
         let squeeze_hint = tracker.majority_expression();
 
         match data {
-            CachedData::MemoryArrow(array) => match transcode_liquid_inner(&array, compressor) {
-                Ok(liquid_array) => (
-                    CacheEntry::with_expression_tracker(
-                        CachedData::MemoryLiquid(liquid_array),
-                        tracker,
-                    ),
-                    None,
-                ),
-                Err(_) => {
-                    let bytes = arrow_to_bytes(&array).expect("failed to convert arrow to bytes");
-                    (
+            CachedData::MemoryArrow(array) => {
+                if let Some(CacheExpression::VariantGet { path }) = squeeze_hint.as_ref()
+                    && let Some((hybrid_array, bytes)) =
+                        try_variant_squeeze(&array, path.as_ref(), compressor)
+                {
+                    return (
                         CacheEntry::with_expression_tracker(
-                            CachedData::DiskArrow(array.data_type().clone()),
+                            CachedData::MemoryHybridLiquid(hybrid_array),
                             tracker,
                         ),
                         Some(bytes),
-                    )
+                    );
                 }
-            },
+                match transcode_liquid_inner(&array, compressor) {
+                    Ok(liquid_array) => (
+                        CacheEntry::with_expression_tracker(
+                            CachedData::MemoryLiquid(liquid_array),
+                            tracker,
+                        ),
+                        None,
+                    ),
+                    Err(_) => {
+                        let bytes =
+                            arrow_to_bytes(&array).expect("failed to convert arrow to bytes");
+                        (
+                            CacheEntry::with_expression_tracker(
+                                CachedData::DiskArrow(array.data_type().clone()),
+                                tracker,
+                            ),
+                            Some(bytes),
+                        )
+                    }
+                }
+            }
             CachedData::MemoryLiquid(liquid_array) => {
                 let (hybrid_array, bytes) = match liquid_array.squeeze(squeeze_hint.as_ref()) {
                     Some(result) => result,
@@ -192,16 +214,171 @@ impl SqueezePolicy for TranscodeEvict {
     }
 }
 
+fn try_variant_squeeze(
+    array: &ArrayRef,
+    path: &str,
+    compressor: &LiquidCompressorStates,
+) -> Option<(LiquidHybridArrayRef, Bytes)> {
+    let struct_array = array.as_any().downcast_ref::<StructArray>()?;
+    let variant_array = VariantArray::try_new(struct_array).ok()?;
+    if variant_array.is_empty() {
+        return None;
+    }
+
+    let metadata = Arc::new(variant_array.metadata_field().clone());
+    let nulls = variant_array.inner().nulls().cloned();
+    let owned_path = path.trim().to_string();
+    if owned_path.is_empty() {
+        return None;
+    }
+    let path_segments: Vec<String> = owned_path
+        .split('.')
+        .map(|segment| segment.trim().to_string())
+        .collect();
+    if path_segments.len() != 1 || path_segments[0].is_empty() {
+        return None;
+    }
+    let field_name = path_segments[0].clone();
+
+    let variant_path = VariantPath::from(owned_path.as_str());
+    let baseline = variant_get(array, GetOptions::new_with_path(variant_path.clone())).ok()?;
+    let baseline_variant = VariantArray::try_new(&baseline).ok()?;
+    let leaf_type = infer_variant_leaf_type(&baseline_variant)?;
+    if !is_supported_leaf_type(&leaf_type) {
+        return None;
+    }
+
+    let field = Arc::new(Field::new("typed_value", leaf_type.clone(), true));
+    let typed_values = variant_get(
+        array,
+        GetOptions::new_with_path(variant_path.clone()).with_as_type(Some(field)),
+    )
+    .ok()?;
+    if typed_values.len() != array.len() {
+        return None;
+    }
+
+    for i in 0..array.len() {
+        if baseline_variant.is_null(i) {
+            continue;
+        }
+        if typed_values.is_null(i) {
+            return None;
+        }
+    }
+
+    let liquid_values = match transcode_liquid_inner(&typed_values, compressor) {
+        Ok(liquid) => liquid,
+        Err(_) => return None,
+    };
+    let bytes = arrow_to_bytes(array).ok()?;
+    let hybrid = VariantExtractedArray::new(
+        field_name,
+        liquid_values,
+        metadata,
+        nulls,
+        array.data_type().clone(),
+    );
+
+    Some((Arc::new(hybrid) as LiquidHybridArrayRef, bytes))
+}
+
+fn infer_variant_leaf_type(array: &VariantArray) -> Option<DataType> {
+    use arrow_schema::TimeUnit;
+    use parquet::variant::Variant;
+
+    for i in 0..array.len() {
+        if array.is_null(i) {
+            continue;
+        }
+        let value = array.value(i);
+        let data_type = match value {
+            Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => {
+                DataType::Int64
+            }
+            Variant::Float(_) | Variant::Double(_) => DataType::Float64,
+            Variant::BooleanTrue | Variant::BooleanFalse => DataType::Boolean,
+            Variant::String(_) | Variant::ShortString(_) => DataType::Utf8,
+            Variant::Binary(_) => DataType::Binary,
+            Variant::Date(_) => DataType::Date32,
+            Variant::TimestampMicros(_) | Variant::TimestampNtzMicros(_) => {
+                DataType::Timestamp(TimeUnit::Microsecond, None)
+            }
+            Variant::TimestampNanos(_) | Variant::TimestampNtzNanos(_) => {
+                DataType::Timestamp(TimeUnit::Nanosecond, None)
+            }
+            _ => continue,
+        };
+        return Some(data_type);
+    }
+    None
+}
+
+fn is_supported_leaf_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Int64
+            | DataType::Float64
+            | DataType::Boolean
+            | DataType::Utf8
+            | DataType::Binary
+            | DataType::Date32
+            | DataType::Timestamp(_, _)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::CacheExpression;
     use crate::cache::cached_batch::CacheEntry;
     use arrow::array::{ArrayRef, Int32Array, StringArray, StructArray};
     use arrow_schema::{DataType, Field};
+    use parquet_variant::VariantPath;
+    use parquet_variant_compute::json_to_variant;
     use std::sync::Arc;
 
     fn int_array(n: i32) -> ArrayRef {
         Arc::new(Int32Array::from_iter_values(0..n))
+    }
+
+    #[test]
+    fn variant_hint_creates_hybrid_array() {
+        let states = LiquidCompressorStates::new();
+        let string_array: ArrayRef = Arc::new(StringArray::from(vec![
+            Some(r#"{"name":"Alice"}"#),
+            Some(r#"{"name":"Bob"}"#),
+            Some(r#"{"name":"Carol"}"#),
+        ]));
+        let variant = json_to_variant(&string_array).expect("variant conversion");
+        let struct_array: StructArray = variant.into();
+        let array: ArrayRef = Arc::new(struct_array);
+
+        let expr = CacheExpression::variant_get("name");
+        let entry = CacheEntry::memory_arrow(array.clone());
+        entry.record_expression_hint(Some(&expr));
+
+        let (new_entry, bytes) = TranscodeSqueezeEvict.squeeze(entry, &states);
+        assert!(bytes.is_some());
+
+        let (data, _) = new_entry.into_parts();
+        let CachedData::MemoryHybridLiquid(hybrid) = data else {
+            panic!("expected hybrid liquid array");
+        };
+
+        let field = Arc::new(Field::new("name", DataType::Utf8, true));
+        let rebuilt = hybrid.to_arrow_array().expect("to arrow");
+        let optimized = variant_get(
+            &rebuilt,
+            GetOptions::new_with_path(VariantPath::from("name")).with_as_type(Some(field.clone())),
+        )
+        .expect("variant_get optimized");
+        let baseline = variant_get(
+            &array,
+            GetOptions::new_with_path(VariantPath::from("name")).with_as_type(Some(field.clone())),
+        )
+        .expect("variant_get baseline");
+        assert_eq!(optimized.as_ref(), baseline.as_ref());
     }
 
     fn decode_arrow(bytes: &Bytes) -> ArrayRef {

--- a/src/storage/src/liquid_array/mod.rs
+++ b/src/storage/src/liquid_array/mod.rs
@@ -14,6 +14,7 @@ mod squeezed_date32_array;
 #[cfg(test)]
 mod tests;
 pub(crate) mod utils;
+mod variant_array;
 
 use std::{any::Any, ops::Range, sync::Arc};
 
@@ -41,6 +42,7 @@ pub use primitive_array::{
     LiquidU8Array, LiquidU16Array, LiquidU32Array, LiquidU64Array,
 };
 pub use squeezed_date32_array::{Date32Field, SqueezedDate32Array};
+pub use variant_array::VariantExtractedArray;
 
 use crate::cache::CacheExpression;
 use crate::liquid_array::byte_view_array::MemoryBuffer;

--- a/src/storage/src/liquid_array/primitive_array.rs
+++ b/src/storage/src/liquid_array/primitive_array.rs
@@ -401,9 +401,7 @@ where
         if T::DATA_TYPE == DataType::Date32 {
             // Special handle for Date32 arrays with component extraction support.
             let field = expression_hint
-                .map(|expr| match expr {
-                    CacheExpression::ExtractDate32 { field } => *field,
-                })
+                .and_then(|expr| expr.as_date32_field())
                 .unwrap_or(Date32Field::Year);
             return Some((
                 Arc::new(SqueezedDate32Array::from_liquid_date32(self, field))

--- a/src/storage/src/liquid_array/squeezed_date32_array.rs
+++ b/src/storage/src/liquid_array/squeezed_date32_array.rs
@@ -12,7 +12,7 @@ use crate::liquid_array::raw::BitPackedArray;
 use crate::utils::get_bit_width;
 
 /// Which component to extract from a `Date32` (days since UNIX epoch).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Date32Field {
     /// Year component
     Year,

--- a/src/storage/src/liquid_array/utils.rs
+++ b/src/storage/src/liquid_array/utils.rs
@@ -1,9 +1,7 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
 
-use crate::{
-    cache::{CacheExpression, CacheExpressionId},
-    liquid_array::Date32Field,
-};
+use crate::cache::CacheExpression;
 
 #[cfg(test)]
 pub(crate) fn gen_test_decimal_array<T: arrow::datatypes::DecimalType>(
@@ -38,118 +36,43 @@ pub(crate) fn gen_test_decimal_array<T: arrow::datatypes::DecimalType>(
         .clone()
 }
 
-const EXPRESSION_SLOT_BITS: usize = 16;
-const EXPRESSION_SLOT_MASK: usize = (1usize << EXPRESSION_SLOT_BITS) - 1;
-const EXPRESSION_SLOT_COUNT: usize = 4;
-const EXPRESSION_EMPTY_VALUE: u16 = u16::MAX;
-
-const fn empty_expression_packed() -> usize {
-    let mut value = 0usize;
-    let mut idx = 0;
-    while idx < EXPRESSION_SLOT_COUNT {
-        value |= (EXPRESSION_EMPTY_VALUE as usize) << (idx * EXPRESSION_SLOT_BITS);
-        idx += 1;
-    }
-    value
-}
-
-const EXPRESSION_EMPTY_PACKED: usize = empty_expression_packed();
-
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("Expression hint tracking requires a 64-bit target pointer width");
-
-fn decode_expression_slots(raw: usize) -> [u16; EXPRESSION_SLOT_COUNT] {
-    let mut slots = [EXPRESSION_EMPTY_VALUE; EXPRESSION_SLOT_COUNT];
-    let mut idx = 0;
-    while idx < EXPRESSION_SLOT_COUNT {
-        let shift = idx * EXPRESSION_SLOT_BITS;
-        let value = (raw >> shift) & EXPRESSION_SLOT_MASK;
-        slots[idx] = value as u16;
-        idx += 1;
-    }
-    slots
-}
-
-fn encode_expression_slots(slots: &[u16; EXPRESSION_SLOT_COUNT]) -> usize {
-    let mut raw = 0usize;
-    let mut idx = 0;
-    while idx < EXPRESSION_SLOT_COUNT {
-        raw |= (slots[idx] as usize) << (idx * EXPRESSION_SLOT_BITS);
-        idx += 1;
-    }
-    raw
-}
+const MAX_HINT_HISTORY: usize = 8;
 
 #[derive(Debug)]
 pub(crate) struct ExpressionHintTracker {
-    packed: AtomicUsize,
+    history: Mutex<VecDeque<CacheExpression>>,
 }
 
 impl ExpressionHintTracker {
     pub(crate) fn new() -> Self {
         Self {
-            packed: AtomicUsize::new(EXPRESSION_EMPTY_PACKED),
+            history: Mutex::new(VecDeque::with_capacity(MAX_HINT_HISTORY)),
         }
-    }
-
-    pub(crate) fn record_date32_field(&self, field: Date32Field) {
-        let id = CacheExpressionId::from_date32_field(field);
-        self.record_expression_id(id);
     }
 
     pub(crate) fn record_expression(&self, expression: &CacheExpression) {
-        match expression {
-            CacheExpression::ExtractDate32 { field } => self.record_date32_field(*field),
+        let mut guard = self.history.lock().unwrap();
+        if guard.len() == MAX_HINT_HISTORY {
+            guard.pop_front();
         }
-    }
-
-    fn record_expression_id(&self, id: CacheExpressionId) {
-        let code = id.raw();
-        if code == EXPRESSION_EMPTY_VALUE {
-            return;
-        }
-        let mut slots = decode_expression_slots(self.packed.load(Ordering::Relaxed));
-        let mut idx = 0;
-        while idx + 1 < EXPRESSION_SLOT_COUNT {
-            slots[idx] = slots[idx + 1];
-            idx += 1;
-        }
-        slots[EXPRESSION_SLOT_COUNT - 1] = code;
-        let encoded = encode_expression_slots(&slots);
-        // here we didn't use compare and swap because we don't care about contention here.
-        self.packed.store(encoded, Ordering::Relaxed);
-    }
-
-    pub(crate) fn majority_date32_field(&self) -> Option<Date32Field> {
-        let slots = decode_expression_slots(self.packed.load(Ordering::Relaxed));
-        let mut best_field = None;
-        let mut best_count = 0u8;
-        let mut best_index = 0usize;
-
-        for (idx, &code) in slots.iter().enumerate() {
-            if code == EXPRESSION_EMPTY_VALUE {
-                continue;
-            }
-
-            let id = CacheExpressionId::from_raw(code);
-            let Some(field) = id.as_date32_field() else {
-                continue;
-            };
-
-            let count = slots.iter().filter(|&&value| value == code).count() as u8;
-            if count > best_count || (count == best_count && idx > best_index) {
-                best_count = count;
-                best_index = idx;
-                best_field = Some(field);
-            }
-        }
-
-        best_field
+        guard.push_back(expression.clone());
     }
 
     pub(crate) fn majority_expression(&self) -> Option<CacheExpression> {
-        self.majority_date32_field()
-            .map(CacheExpression::extract_date32)
+        let guard = self.history.lock().unwrap();
+        if guard.is_empty() {
+            return None;
+        }
+        let mut counts: HashMap<&CacheExpression, (usize, usize)> = HashMap::new();
+        for (idx, expr) in guard.iter().enumerate() {
+            let entry = counts.entry(expr).or_insert((0, idx));
+            entry.0 += 1;
+            entry.1 = idx;
+        }
+        counts
+            .into_iter()
+            .max_by(|a, b| a.1.0.cmp(&b.1.0).then(a.1.1.cmp(&b.1.1)))
+            .map(|(expr, _)| expr.clone())
     }
 }
 
@@ -161,9 +84,9 @@ impl Default for ExpressionHintTracker {
 
 impl Clone for ExpressionHintTracker {
     fn clone(&self) -> Self {
-        let value = self.packed.load(Ordering::Relaxed);
+        let history = self.history.lock().unwrap().clone();
         Self {
-            packed: AtomicUsize::new(value),
+            history: Mutex::new(history),
         }
     }
 }
@@ -171,29 +94,35 @@ impl Clone for ExpressionHintTracker {
 #[cfg(test)]
 mod tests {
     use super::ExpressionHintTracker;
-    use crate::liquid_array::Date32Field;
+    use crate::{cache::CacheExpression, liquid_array::Date32Field};
 
     #[test]
     fn majority_date32_field_returns_most_frequent_field() {
         let tracker = ExpressionHintTracker::new();
 
-        tracker.record_date32_field(Date32Field::Year);
-        tracker.record_date32_field(Date32Field::Month);
-        tracker.record_date32_field(Date32Field::Year);
-        tracker.record_date32_field(Date32Field::Year);
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Year));
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Month));
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Year));
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Year));
 
-        assert_eq!(tracker.majority_date32_field(), Some(Date32Field::Year));
+        assert_eq!(
+            tracker.majority_expression(),
+            Some(CacheExpression::extract_date32(Date32Field::Year))
+        );
     }
 
     #[test]
     fn majority_date32_field_prefers_most_recent_on_tie() {
         let tracker = ExpressionHintTracker::new();
 
-        tracker.record_date32_field(Date32Field::Year);
-        tracker.record_date32_field(Date32Field::Month);
-        tracker.record_date32_field(Date32Field::Year);
-        tracker.record_date32_field(Date32Field::Month);
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Year));
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Month));
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Year));
+        tracker.record_expression(&CacheExpression::extract_date32(Date32Field::Month));
 
-        assert_eq!(tracker.majority_date32_field(), Some(Date32Field::Month));
+        assert_eq!(
+            tracker.majority_expression(),
+            Some(CacheExpression::extract_date32(Date32Field::Month))
+        );
     }
 }

--- a/src/storage/src/liquid_array/variant_array.rs
+++ b/src/storage/src/liquid_array/variant_array.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, BinaryViewArray, StructArray};
+use arrow::buffer::NullBuffer;
+use arrow_schema::{DataType, Field, Fields};
+
+use crate::liquid_array::{IoRange, LiquidArrayRef, LiquidDataType, LiquidHybridArray};
+
+/// Hybrid representation for a single top-level variant field.
+#[derive(Debug)]
+pub struct VariantExtractedArray {
+    field_name: Arc<str>,
+    values: LiquidArrayRef,
+    metadata: Arc<BinaryViewArray>,
+    nulls: Option<NullBuffer>,
+    original_arrow_type: DataType,
+}
+
+impl VariantExtractedArray {
+    /// Build a hybrid array for the provided top-level variant field.
+    pub fn new(
+        field_name: impl Into<Arc<str>>,
+        values: LiquidArrayRef,
+        metadata: Arc<BinaryViewArray>,
+        nulls: Option<NullBuffer>,
+        original_arrow_type: DataType,
+    ) -> Self {
+        Self {
+            field_name: field_name.into(),
+            values,
+            metadata,
+            nulls,
+            original_arrow_type,
+        }
+    }
+
+    /// Field name carried by this hybrid array.
+    pub fn field(&self) -> &str {
+        self.field_name.as_ref()
+    }
+}
+
+impl LiquidHybridArray for VariantExtractedArray {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn get_array_memory_size(&self) -> usize {
+        self.metadata.get_array_memory_size() + self.values.get_array_memory_size()
+    }
+
+    fn len(&self) -> usize {
+        self.metadata.len()
+    }
+
+    fn to_arrow_array(&self) -> Result<ArrayRef, IoRange> {
+        let arrow_values = self.values.to_arrow_array();
+        let leaf_field = Arc::new(Field::new(
+            "typed_value",
+            arrow_values.data_type().clone(),
+            arrow_values.null_count() > 0,
+        ));
+        let leaf_struct = Arc::new(StructArray::new(
+            Fields::from(vec![leaf_field]),
+            vec![arrow_values.clone()],
+            arrow_values.nulls().cloned(),
+        ));
+
+        let named_field = Arc::new(Field::new(
+            self.field_name.as_ref(),
+            leaf_struct.data_type().clone(),
+            true,
+        ));
+        let typed_struct = Arc::new(StructArray::new(
+            Fields::from(vec![named_field]),
+            vec![leaf_struct as ArrayRef],
+            self.nulls.clone(),
+        ));
+
+        let value_placeholder =
+            Arc::new(BinaryViewArray::from(vec![None::<&[u8]>; self.len()])) as ArrayRef;
+
+        let root_fields = Fields::from(vec![
+            Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+            Arc::new(Field::new("value", DataType::BinaryView, true)),
+            Arc::new(Field::new(
+                "typed_value",
+                typed_struct.data_type().clone(),
+                true,
+            )),
+        ]);
+
+        Ok(Arc::new(StructArray::new(
+            root_fields,
+            vec![
+                self.metadata.clone() as ArrayRef,
+                value_placeholder,
+                typed_struct,
+            ],
+            self.nulls.clone(),
+        )))
+    }
+
+    fn data_type(&self) -> LiquidDataType {
+        LiquidDataType::ByteArray
+    }
+
+    fn original_arrow_data_type(&self) -> DataType {
+        self.original_arrow_type.clone()
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, IoRange> {
+        Err(IoRange { range: 0..0 })
+    }
+
+    fn filter(&self, selection: &arrow::buffer::BooleanBuffer) -> Result<ArrayRef, IoRange> {
+        let array = self.to_arrow_array()?;
+        let selection = arrow::array::BooleanArray::new(selection.clone(), None);
+        Ok(arrow::compute::filter(&array, &selection).unwrap())
+    }
+
+    fn try_eval_predicate(
+        &self,
+        _predicate: &Arc<dyn datafusion::physical_plan::PhysicalExpr>,
+        _filter: &arrow::buffer::BooleanBuffer,
+    ) -> Result<Option<arrow::array::BooleanArray>, IoRange> {
+        Ok(None)
+    }
+
+    fn soak(&self, _data: bytes::Bytes) -> LiquidArrayRef {
+        Arc::clone(&self.values)
+    }
+
+    fn to_liquid(&self) -> IoRange {
+        IoRange { range: 0..0 }
+    }
+}


### PR DESCRIPTION
This pr hooks the lineage analyze and the liquid cache.

But it has two limitations:
1. We can only shred a single top level field from the variant.
2. The metadata overhead is extremely high right now. We will fix this in later PRs.