### PR TITLE
Reduce metadata overhead

### DIFF
--- a/src/storage/src/cache/cached_batch.rs
+++ b/src/storage/src/cache/cached_batch.rs
@@ -6,7 +6,7 @@ use arrow::array::ArrayRef;
 use arrow_schema::DataType;
 
 use crate::{
-    cache::CacheExpression,
+    cache::ExpressionId,
     liquid_array::utils::ExpressionHintTracker,
     liquid_array::{LiquidArrayRef, LiquidHybridArrayRef},
 };
@@ -84,7 +84,7 @@ impl CacheEntry {
     fn new(data: CachedData) -> Self {
         Self {
             data,
-            expression_hints: ExpressionHintTracker::default(),
+            expression_hints: ExpressionHintTracker::new(),
         }
     }
 
@@ -120,14 +120,14 @@ impl CacheEntry {
     }
 
     /// Record an optional expression hint for this cached batch.
-    pub fn record_expression_hint(&self, expression_hint: Option<&CacheExpression>) {
+    pub fn record_expression_hint(&self, expression_hint: Option<ExpressionId>) {
         if let Some(expression) = expression_hint {
             self.expression_hints.record_expression(expression);
         }
     }
 
     /// Derive the expression hint (if any) preferred for squeezing.
-    pub fn expression_hint_for_squeeze(&self) -> Option<CacheExpression> {
+    pub fn expression_hint_for_squeeze(&self) -> Option<ExpressionId> {
         self.expression_hints.majority_expression()
     }
 }

--- a/src/storage/src/cache/expressions.rs
+++ b/src/storage/src/cache/expressions.rs
@@ -1,6 +1,8 @@
 //! Definitions for cache-aware expressions that can be applied when materializing arrays.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::num::NonZeroU16;
+use std::sync::{Arc, RwLock};
 
 use crate::liquid_array::Date32Field;
 
@@ -58,5 +60,104 @@ impl CacheExpression {
             Self::VariantGet { path } => Some(path.as_ref()),
             Self::ExtractDate32 { .. } => None,
         }
+    }
+}
+
+/// Identifier assigned to a registered cache expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ExpressionId(NonZeroU16);
+
+impl ExpressionId {
+    /// Try to build an [`ExpressionId`] from a raw 16-bit value.
+    pub fn from_raw(raw: u16) -> Option<Self> {
+        NonZeroU16::new(raw).map(Self)
+    }
+
+    /// Numerical representation of the identifier.
+    pub fn as_raw(self) -> u16 {
+        self.0.get()
+    }
+
+    /// Zero-based index into the registry backing-store.
+    fn index(self) -> usize {
+        (self.0.get() as usize) - 1
+    }
+}
+
+const MAX_REGISTERED_EXPRESSIONS: usize = u16::MAX as usize;
+
+#[derive(Debug)]
+struct ExpressionRegistryInner {
+    expressions: Vec<Arc<CacheExpression>>,
+    lookup: HashMap<CacheExpression, ExpressionId>,
+}
+
+impl ExpressionRegistryInner {
+    fn new() -> Self {
+        Self {
+            expressions: Vec::new(),
+            lookup: HashMap::new(),
+        }
+    }
+}
+
+/// Registry that assigns stable identifiers to [`CacheExpression`] values.
+#[derive(Debug)]
+pub struct ExpressionRegistry {
+    inner: RwLock<ExpressionRegistryInner>,
+}
+
+impl ExpressionRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(ExpressionRegistryInner::new()),
+        }
+    }
+
+    /// Register the provided expression and return its identifier.
+    ///
+    /// Returns `None` if the registry has reached capacity.
+    pub fn register(&self, expression: CacheExpression) -> Option<ExpressionId> {
+        {
+            let guard = self.inner.read().unwrap();
+            if let Some(id) = guard.lookup.get(&expression) {
+                return Some(*id);
+            }
+        }
+
+        let mut guard = self.inner.write().unwrap();
+        if let Some(id) = guard.lookup.get(&expression) {
+            return Some(*id);
+        }
+
+        if guard.expressions.len() == MAX_REGISTERED_EXPRESSIONS {
+            return None;
+        }
+
+        let next_index = guard.expressions.len() + 1;
+        let raw = u16::try_from(next_index).ok()?;
+        let id = ExpressionId::from_raw(raw)?;
+        guard.lookup.insert(expression.clone(), id);
+        guard.expressions.push(Arc::new(expression));
+        Some(id)
+    }
+
+    /// Look up the identifier for a previously registered expression.
+    pub fn id(&self, expression: &CacheExpression) -> Option<ExpressionId> {
+        let guard = self.inner.read().unwrap();
+        guard.lookup.get(expression).copied()
+    }
+
+    /// Resolve the identifier into the stored expression.
+    pub fn get(&self, id: ExpressionId) -> Option<Arc<CacheExpression>> {
+        let guard = self.inner.read().unwrap();
+        guard.expressions.get(id.index()).cloned()
+    }
+}
+
+impl Default for ExpressionRegistry {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/storage/src/cache/mod.rs
+++ b/src/storage/src/cache/mod.rs
@@ -18,7 +18,7 @@ pub use core::{
     BlockingIoContext, CacheStorage, CacheStorageBuilder, DefaultIoContext, EvaluatePredicate, Get,
     Insert, IoContext,
 };
-pub use expressions::CacheExpression;
+pub use expressions::{CacheExpression, ExpressionId, ExpressionRegistry};
 pub use stats::{CacheStats, RuntimeStats, RuntimeStatsSnapshot};
 pub use transcode::transcode_liquid_inner;
 pub use utils::{EntryID, LiquidCompressorStates};

--- a/src/storage/src/liquid_array/primitive_array.rs
+++ b/src/storage/src/liquid_array/primitive_array.rs
@@ -747,7 +747,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::CacheExpression;
+    use crate::cache::{CacheExpression, ExpressionRegistry};
     use crate::liquid_array::utils::ExpressionHintTracker;
     use arrow::array::Array;
 
@@ -882,18 +882,24 @@ mod tests {
         let original = vec![Some(0), Some(31), Some(59), None, Some(90)];
         let array = PrimitiveArray::<Date32Type>::from(original);
         let liquid = LiquidPrimitiveArray::<Date32Type>::from_arrow_array(array);
+        let registry = ExpressionRegistry::new();
 
-        let expr_month = CacheExpression::extract_date32(Date32Field::Month);
-        let expr_year = CacheExpression::extract_date32(Date32Field::Year);
+        let expr_month = registry
+            .register(CacheExpression::extract_date32(Date32Field::Month))
+            .expect("register month");
+        let expr_year = registry
+            .register(CacheExpression::extract_date32(Date32Field::Year))
+            .expect("register year");
 
         let tracker = ExpressionHintTracker::new();
-        tracker.record_expression(&expr_month);
-        tracker.record_expression(&expr_month);
-        tracker.record_expression(&expr_year);
-        let majority = tracker.majority_expression();
+        tracker.record_expression(expr_month);
+        tracker.record_expression(expr_month);
+        tracker.record_expression(expr_year);
+        let majority = tracker.majority_expression().expect("majority id");
+        let majority_expr = registry.get(majority).expect("resolve majority");
 
         let (hybrid, _) = liquid
-            .squeeze(majority.as_ref())
+            .squeeze(Some(majority_expr.as_ref()))
             .expect("squeeze should succeed");
         let squeezed = hybrid
             .as_any()
@@ -908,15 +914,23 @@ mod tests {
         let original = vec![Some(0), Some(1), Some(2), Some(3)];
         let array = PrimitiveArray::<Date32Type>::from(original);
         let liquid = LiquidPrimitiveArray::<Date32Type>::from_arrow_array(array);
+        let registry = ExpressionRegistry::new();
 
-        let expr_year = CacheExpression::extract_date32(Date32Field::Year);
-        let expr_day = CacheExpression::extract_date32(Date32Field::Day);
+        let expr_year = registry
+            .register(CacheExpression::extract_date32(Date32Field::Year))
+            .expect("register year");
+        let expr_day = registry
+            .register(CacheExpression::extract_date32(Date32Field::Day))
+            .expect("register day");
         let tracker = ExpressionHintTracker::new();
-        tracker.record_expression(&expr_year);
-        tracker.record_expression(&expr_day);
+        tracker.record_expression(expr_year);
+        tracker.record_expression(expr_day);
+
+        let majority = tracker.majority_expression().expect("majority id");
+        let majority_expr = registry.get(majority).expect("resolve expression");
 
         let (hybrid, _) = liquid
-            .squeeze(tracker.majority_expression().as_ref())
+            .squeeze(Some(majority_expr.as_ref()))
             .expect("squeeze should succeed");
         let squeezed = hybrid
             .as_any()


### PR DESCRIPTION
This pr reduces the metadata overhead back to 8 byte per entry, which was increased to 40 by previous pr.
We introduced a metadata registry concept.