### PR TITLE
chore: release v0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "dev-tools"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dioxus",
 ]
@@ -4111,7 +4111,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "liquid-cache"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "ahash",
  "arrow",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "liquid-cache-common"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "liquid-cache-datafusion"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "ahash",
  "arrow",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "liquid-cache-datafusion-client"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "liquid-cache-datafusion-local"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "liquid-cache-datafusion-server"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4309,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "liquid-cache-fuzz"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "arbitrary",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 repository = "https://github.com/XiangpengHao/liquid-cache"
 authors = ["XiangpengHao <xiangpeng.hao@wisc.edu>"]
@@ -24,12 +24,12 @@ members = [
 resolver = "3"
 
 [workspace.dependencies]
-liquid-cache-datafusion-server = { path = "src/datafusion-server", version = "0.1.12" }
-liquid-cache-datafusion-client = { path = "src/datafusion-client", version = "0.1.12" }
-liquid-cache-datafusion = { path = "src/datafusion", version = "0.1.12" }
-liquid-cache-common = { path = "src/common", version = "0.1.12" }
-liquid-cache = { path = "src/core", version = "0.1.12" }
-liquid-cache-datafusion-local = { path = "src/datafusion-local", version = "0.1.12" }
+liquid-cache-datafusion-server = { path = "src/datafusion-server", version = "0.1.13" }
+liquid-cache-datafusion-client = { path = "src/datafusion-client", version = "0.1.13" }
+liquid-cache-datafusion = { path = "src/datafusion", version = "0.1.13" }
+liquid-cache-common = { path = "src/common", version = "0.1.13" }
+liquid-cache = { path = "src/core", version = "0.1.13" }
+liquid-cache-datafusion-local = { path = "src/datafusion-local", version = "0.1.13" }
 arrow = { version = "58.1.0", default-features = false, features = [
 	"prettyprint",
 	"ipc",

--- a/dev/dev-tools/Cargo.toml
+++ b/dev/dev-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dev-tools"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["XiangpengHao <me@xiangpeng.systems>"]
 edition = "2024"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liquid-cache-fuzz"
-version = "0.1.12"
+version = "0.1.13"
 publish = false
 edition = "2024"
 


### PR DESCRIPTION
## Release v0.1.13

This PR bumps all workspace crate versions to `0.1.13`.



---

**On merge**, the `publish.yml` workflow will automatically:
1. Publish all crates to crates.io
2. Create a GitHub Release with tag `v0.1.13`