### PR TITLE
Propagate file_size to ParquetObjectReader in CachedMetaReaderFactory

### DIFF
--- a/src/datafusion/src/reader/plantime/source.rs
+++ b/src/datafusion/src/reader/plantime/source.rs
@@ -59,7 +59,8 @@ impl CachedMetaReaderFactory {
     ) -> ParquetMetadataCacheReader {
         let path = partitioned_file.object_meta.location.clone();
         let store = Arc::clone(&self.store);
-        let mut inner = ParquetObjectReader::new(store, path.clone());
+        let mut inner = ParquetObjectReader::new(store, path.clone())
+            .with_file_size(partitioned_file.object_meta.size);
 
         if let Some(hint) = metadata_size_hint {
             inner = inner.with_footer_size_hint(hint);


### PR DESCRIPTION
CachedMetaReaderFactory::create_liquid_reader constructed its inner ParquetObjectReader without the known file size, forcing parquet 58.x onto the suffix-fetch metadata path. With a large metadata_size_hint and a file containing page indexes, that path can slice page-index ranges against a retained suffix using the wrong base offset, panicking with `assertion failed: end <= remainder.len()`.

Forward the already-known object_meta.size via with_file_size() so metadata loading uses the size-aware bounded-range path, matching DataFusion's parquet reader factories.

Fixes #503